### PR TITLE
Workaround OS X ACPI crash on suspend/resume

### DIFF
--- a/include/xhyve/vmm/vmm.h
+++ b/include/xhyve/vmm/vmm.h
@@ -108,6 +108,8 @@ extern struct vmm_ops vmm_ops_intel;
 int vmm_init(void);
 int vmm_cleanup(void);
 int vm_create(struct vm **retvm);
+void vm_signal_pause(struct vm *vm, bool pause);
+void vm_check_for_unpause(struct vm *vm, int vcpuid);
 int vcpu_create(struct vm *vm, int vcpu);
 void vm_destroy(struct vm *vm);
 void vcpu_destroy(struct vm *vm, int vcpu);

--- a/include/xhyve/vmm/vmm_api.h
+++ b/include/xhyve/vmm/vmm_api.h
@@ -45,6 +45,7 @@ enum vm_mmap_style {
 	VM_MMAP_SPARSE,		/* mappings created on-demand */
 };
 
+void xh_hv_pause(int pause);
 int xh_vm_create(void);
 void xh_vm_destroy(void);
 int xh_vcpu_create(int vcpu);

--- a/include/xhyve/vmm/vmm_mem.h
+++ b/include/xhyve/vmm/vmm_mem.h
@@ -36,3 +36,5 @@ struct vmspace;
 int	vmm_mem_init(void);
 void *vmm_mem_alloc(uint64_t gpa, size_t size);
 void vmm_mem_free(uint64_t gpa, size_t size, void *object);
+void vmm_mem_protect(uint64_t gpa, size_t size);
+void vmm_mem_unprotect(uint64_t gpa, size_t size);

--- a/src/vmm/intel/vmx.c
+++ b/src/vmm/intel/vmx.c
@@ -2189,6 +2189,9 @@ vmx_run(void *arg, int vcpu, register_t rip, void *rendezvous_cookie,
 		}
 		vmx_exit_trace(vmx, vcpu, ((uint64_t) rip), exit_reason, handled);
 		rip = (register_t) vmexit->rip;
+
+		vm_check_for_unpause(vm, vcpu);
+
 	} while (handled);
 
 	/*

--- a/src/vmm/vmm_api.c
+++ b/src/vmm/vmm_api.c
@@ -81,6 +81,11 @@ vcpu_freeze_all(bool freeze)
 	}
 }
 
+void xh_hv_pause(int pause) {
+	assert(vm != NULL);
+	vm_signal_pause(vm, (pause != 0));
+}
+
 int
 xh_vm_create(void)
 {

--- a/src/vmm/vmm_mem.c
+++ b/src/vmm/vmm_mem.c
@@ -67,3 +67,13 @@ vmm_mem_free(uint64_t gpa, size_t size, void *object)
 	hv_vm_unmap(gpa, size);
 	free(object);
 }
+
+void
+vmm_mem_protect(uint64_t gpa, size_t size) {
+	hv_vm_protect(gpa, size, 0);
+}
+
+void
+vmm_mem_unprotect(uint64_t gpa, size_t size) {
+	hv_vm_protect(gpa, size, (HV_MEMORY_READ | HV_MEMORY_WRITE | HV_MEMORY_EXEC));
+}


### PR DESCRIPTION
This may fix/avoid the OSX ACPI/Hypervisor framework crash issue without
rebooting the VM. I've run it overnight on two laptops with 10.11.2 and 10.11.3
without any crashes and tested it 10+ times with short hibernation timeouts and
sleep/wakeup. However, since we don't have a test that can reproduce this issue
all the time it needs testing on more systems to be sure that it actually
works.

Freeze is implemented by adding a condition variable in the hv_vcpu_run
interrupt loop, which each vcpu thread will wait on if SIGUSR1 has been
received. Before waiting the vcpu is set to a frozen state and memory is
protected by setting it -rwx. The memory protection may not be necessary, but
I'm hoping it will give us a better error message if the crash happens again.
The theads are resumed on SIGUSR2.

This currently requires an external agent to send the SIGUSR{1,2} upon
{suspend,resume}. Perhaps an event listening for power events should be used
instead.

Signed-off-by: Magnus Skjegstad magnus@skjegstad.com
