### PR TITLE
vsock: optional prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,12 @@ HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow uri >/dev/null 2>/dev/null ; 
 ifeq ($(HAVE_OCAML_QCOW),YES)
 CFLAGS += -DHAVE_OCAML=1 -DHAVE_OCAML_QCOW=1 -DHAVE_OCAML=1
 
+# prefix vsock file names if PRI_ADDR_PREFIX
+# is defined. (not applied to aliases)
+ifneq ($(PRI_ADDR_PREFIX),)
+CFLAGS += -DPRI_ADDR_PREFIX=\"$(PRI_ADDR_PREFIX)\"
+endif
+
 OCAML_SRC := \
 	src/mirage_block_ocaml.ml
 


### PR DESCRIPTION
I need a way to prefix vsock filenames. What's in that PR works for me (using a CFLAG to define an optional PRI_ADDR_PREFIX macro). 

cc @ijc25 

Signed-off-by: Gaetan de Villele gdevillele@gmail.com
