### PR TITLE
Manpage/documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ ruling it out in the future.
 
 The resulting binary will be in `build/com.docker.hyperkit`
 
+To enable qcow support in the block backend an ocaml OPAM development
+environment is required with the qcow-format module available. A
+suitable environment can be setup by installing `opam` via `brew` and
+using that to install the appropriate libraries:
+
+    $ brew install opam
+    $ opam init
+    $ eval `opam config env`
+    $ opam install sexplib=113.00.00 uri qcow-format ocamlfind
+
+Notes:
+
+- `opam config env` must be evaluated each time prior to building
+  hyperkit so the build will find the ocaml environment.
+- An explicit older version of sexplib is currently required to build
+  qcow format 0.2
+
 ## Usage
 
     $ com.docker.hyperkit -h

--- a/hyperkit.1
+++ b/hyperkit.1
@@ -24,10 +24,10 @@
 .\" SUCH DAMAGE.
 .\"
 .Dd September 11, 2015
-.Dt XHYVE 1
+.Dt HYPERKIT 1
 .Os
 .Sh NAME
-.Nm xhyve
+.Nm hyperkit
 .Nd "run a guest operating system inside a virtual machine"
 .Sh SYNOPSIS
 .Nm
@@ -92,9 +92,7 @@ Allow devices behind the LPC PCI-ISA bridge to be configured.
 The only supported devices are the TTY-class devices
 .Ar com1
 and
-.Ar com2
-and the boot ROM device
-.Ar bootrom .
+.Ar com2.
 .It Fl m Ar size Ns Op Ar K|k|M|m|G|g|T|t
 Guest physical memory size in bytes.
 .Pp
@@ -156,6 +154,8 @@ Virtio network interface.
 Virtio block storage interface.
 .It Li virtio-rnd
 Virtio RNG interface.
+.It Li virtio-9p
+Virtio 9P backend bridge.
 .It Li ahci-cd
 AHCI controller attached to an ATAPI CD/DVD.
 .It Li ahci-hd
@@ -163,7 +163,7 @@ AHCI controller attached to a SATA hard-drive.
 .It Li uart
 PCI 16550 serial device.
 .It Li lpc
-LPC PCI-ISA bridge with COM1 and COM2 16550 serial ports and a boot ROM.
+LPC PCI-ISA bridge with COM1 and COM2 16550 serial ports.
 The LPC bridge emulation can only be configured on bus 0.
 .El
 .It Op Ar conf
@@ -193,6 +193,7 @@ Block storage devices:
 .Bl -tag -width 10n
 .It Pa /filename Ns Oo , Ns Ar block-device-options Oc
 .It Pa /dev/xxx Ns Oo , Ns Ar block-device-options Oc
+.It file:///filename.qcow, Ns format=qcow Ns Oo , Ns Ar block-device-options Oc
 .El
 .Pp
 The
@@ -211,25 +212,48 @@ Force the file to be opened read-only.
 Specify the logical and physical sector sizes of the emulated disk.
 The physical sector size is optional and is equal to the logical sector size
 if not explicitly specified.
+.It format=qcow
+Indicates that the image is in qcow format. The filename must be
+given in the URL syntax.
+.El
+.Pp
+9P backend:
+.Bl -tag -width 10n
+.It port= Ns Ar port Ns Oo , Ns Ar 9p-device-options Oc
+Connect to server listening on the loopback device at the given port
+.It path= Ns Ar path Ns Oo , Ns Ar 9p-device-options Oc
+Connect to server listening on the given Unix domain socket
+.El
+.Pp
+The
+.Ar 9p-device-options
+are:
+.Bl -tag -width 8n
+.It Li tag= Ns Ar mount-tag Ns
+The 9p mount tag
 .El
 .Pp
 TTY devices:
 .Bl -tag -width 10n
-.It Li stdio
+.It Li stdio Ns Oo , Ns Ar uart-device-options Oc
 Connect the serial port to the standard input and output of
 the
 .Nm
 process.
-.It Pa /dev/xxx
+.It Pa /dev/xxx Ns Oo , Ns Ar uart-device-options Oc
 Use the host TTY device for serial port I/O.
+.It Pa autopty Ns Oo , Ns Ar uart-device-options Oc
+Automatically select a host TTY device.
+.It Pa autopty=/path/to/symlink Ns Oo , Ns Ar uart-device-options Oc
+Automatically select a host TTY device and setup a convenience symlink.
 .El
 .Pp
-Boot ROM device:
-.Bl -tag -width 10n
-.It Pa romfile
-Map
-.Ar romfile
-in the guest address space reserved for boot firmware.
+The
+.Ar uart-device-options
+are:
+.Bl -tag -width 8n
+.It Pa log=/path/to/ring-log
+Also log output to a ring buffer
 .El
 .Pp
 Pass-through devices:
@@ -266,8 +290,25 @@ interrupts.
 The guest's local APIC is configured in x2APIC mode.
 .It Fl Y
 Disable MPtable generation.
-.It Fl f Ar firmware
-TODO Explain this!
+.It Fl f Ar firmware,arg1,arg2,arg3
+.Pp
+Firmware/bootrom configuration.
+.Bl -tag -width 10n
+.It kexec , Ns Pa kernel , Ns Oo Pa ramdisk Ns Oc , Ns Oo Pa cmdline Oc
+Launch
+.Ar kernel
+using the Linux kexec protocol.
+.It fbsd , Ns Pa userboot , Ns Pa bootvolume , Ns Pa kernelenv
+Boot using the fbsd protocol
+.It bootrom , Ns Pa path , Ns ,
+Boot using
+.Ar path
+as a firmware image. Allows booting a UEFI/tianocore binary, such as
+the one from bhyve (source: <https://github.com/freebsd/uefi-edk2.git>; binary <https://people.freebsd.org/~grehan/bhyve_uefi/>).
+.El
+.Pp
+Note that all the commas are required in each case, even if the
+options are empty.
 .El
 .Sh EXAMPLES
 To run a virtual machine with 1GB of memory, two virtual CPUs, a virtio
@@ -275,7 +316,7 @@ block device backed by the
 .Pa /my/image
 filesystem image, and a serial port for the console:
 .Bd -literal -offset indent
-xhyve -c 2 -s 0,hostbridge -s 1,lpc -s 2,virtio-blk,/my/image \\
+hyperkit -c 2 -s 0,hostbridge -s 1,lpc -s 2,virtio-blk,/my/image \\
   -l com1,stdio -A -H -P -m 1G \\
   -f kexec,vmlinuz,initrd.gz,"earlyprintk=serial console=ttyS0"
 .Ed
@@ -283,7 +324,7 @@ xhyve -c 2 -s 0,hostbridge -s 1,lpc -s 2,virtio-blk,/my/image \\
 Run a 24GB single-CPU virtual machine with three network ports, one of which
 has a MAC address specified:
 .Bd -literal -offset indent
-xhyve -s 0,hostbridge -s 1,lpc -s 2:0,virtio-net,tap0 \\
+hyperkit -s 0,hostbridge -s 1,lpc -s 2:0,virtio-net,tap0 \\
   -s 2:1,virtio-net,tap1 \\
   -s 2:2,virtio-net,tap2,mac=00:be:fa:76:45:00 \\
   -s 3,virtio-blk,/my/image -l com1,stdio \\
@@ -296,7 +337,7 @@ port connected to an
 .Xr nmdm 4
 null-modem device.
 .Bd -literal -offset indent
-xhyve -c 4 \\
+hyperkit -c 4 \\
   -s 0,amd_hostbridge -s 1,lpc \\
   -s 1:0,ahci-hd,/images/disk.1 \\
   -s 1:1,ahci-hd,/images/disk.2 \\
@@ -313,9 +354,20 @@ xhyve -c 4 \\
   -f kexec,vmlinuz,initrd.gz,"earlyprintk=serial console=ttyS0"
 
 .Ed
+
+.Sh SIGNALS
+.Bl -tag -width 10n
+.It Pa SIGUSR1
+Pause all VCPU threads
+.It Pa SIGUSR2
+Unpause all VCPU threads
+.El
+
 .Sh HISTORY
 .Nm
 is a port of FreeBSD's bhyve hypervisor to OS X that
 works entirely in userspace and has no other dependencies.
 .Sh AUTHORS
 .An Michael Steil Aq Mt mist64@mac.com
+
+.\ net ipc

--- a/src/pci_virtio_net_ipc.c
+++ b/src/pci_virtio_net_ipc.c
@@ -883,8 +883,8 @@ pci_vtnet_init(struct pci_devinst *pi, char *opts)
 	pthread_t sthrd;
 
 	if (!aslInitDone) {
-		aslInit("Docker", "com.docker.xhyve");
-		aslLog(ASL_LEVEL_NOTICE, "Starting xhyve");
+		aslInit("Docker", "com.docker.hyperkit");
+		aslLog(ASL_LEVEL_NOTICE, "Starting hyperkit");
 		aslInitDone = 1;
 	}
 


### PR DESCRIPTION
Covering:
- virtio-9p
- qcowblock backend
- VCPU pausing/unpausing
- UART logging and TTY symlink
- Bootrom support

Signed-off-by: Ian Campbell ian.campbell@docker.com
