### PR TITLE
vsock: allow connect socket name to be overridden

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,12 @@ ifneq ($(PRI_ADDR_PREFIX),)
 CFLAGS += -DPRI_ADDR_PREFIX=\"$(PRI_ADDR_PREFIX)\"
 endif
 
+# override default connect socket name if 
+# CONNECT_SOCKET_NAME is defined 
+ifneq ($(CONNECT_SOCKET_NAME),)
+CFLAGS += -DCONNECT_SOCKET_NAME=\"$(CONNECT_SOCKET_NAME)\"
+endif
+
 OCAML_SRC := \
 	src/mirage_block_ocaml.ml
 

--- a/src/pci_virtio_sock.c
+++ b/src/pci_virtio_sock.c
@@ -143,6 +143,10 @@ struct vsock_addr {
 #define PRIaddr PRIcid "." PRIport
 #endif
 
+#ifndef CONNECT_SOCKET_NAME
+#define CONNECT_SOCKET_NAME "connect"
+#endif
+
 #define FMTADDR(a) a.cid, a.port
 
 #define WRITE_BUF_LENGTH (128*1024)
@@ -1896,7 +1900,7 @@ static int open_connect_socket(struct pci_vtsock_softc *sc)
 	un.sun_len = 0; /* Unused? */
 	un.sun_family = AF_UNIX;
 	rc = snprintf(un.sun_path, sizeof(un.sun_path),
-		     "%s/connect", sc->path);
+		     "%s/"CONNECT_SOCKET_NAME, sc->path);
 	if (rc < 0) {
 		perror("Failed to format connect socket path");
 		return 1;


### PR DESCRIPTION
Signed-off-by: Gaetan de Villele gdevillele@gmail.com
