### PR TITLE
Name each pthread as an aid to debugging.

### DIFF
--- a/src/block_if.c
+++ b/src/block_if.c
@@ -90,6 +90,7 @@ struct blockif_elem {
 
 struct blockif_ctxt {
 	int bc_magic;
+	char ident[16];
 	/* Only one of fd and bc_mbh may be >= 0 */
 	int bc_fd;
 #ifdef HAVE_OCAML_QCOW
@@ -421,6 +422,8 @@ blockif_thr(void *arg)
 		buf = NULL;
 	t = pthread_self();
 
+	pthread_setname_np(bc->ident);
+
 	pthread_mutex_lock(&bc->bc_mtx);
 	for (;;) {
 		while (blockif_dequeue(bc, t, &be)) {
@@ -476,7 +479,7 @@ blockif_init(void)
 }
 
 struct blockif_ctxt *
-blockif_open(const char *optstr, UNUSED const char *ident)
+blockif_open(const char *optstr, const char *ident)
 {
 	// char name[MAXPATHLEN];
 	char *nopt, *xopts, *cp;
@@ -640,6 +643,7 @@ blockif_open(const char *optstr, UNUSED const char *ident)
 	}
 
 	bc->bc_magic = (int) BLOCKIF_SIG;
+	snprintf(bc->ident, sizeof(bc->ident), "blk:%s", ident);
 	bc->bc_fd = fd;
 #ifdef HAVE_OCAML_QCOW
 	bc->bc_mbh = mbh;

--- a/src/pci_virtio_9p.c
+++ b/src/pci_virtio_9p.c
@@ -323,6 +323,10 @@ pci_vt9p_thread(void *vsc)
 	int i, ii, j;
 	struct iovec *wiov;
 	uint8_t *buf;
+	char ident[16];
+
+	snprintf(ident, sizeof(ident), "9p:%s", sc->v9sc_cfg.tag);
+	pthread_setname_np(ident);
 
 	buf = calloc(1, BUFSIZE);
 	if (! buf) {

--- a/src/pci_virtio_net_tap.c
+++ b/src/pci_virtio_net_tap.c
@@ -393,6 +393,8 @@ pci_vtnet_tap_select_func(void *vsc) {
 	struct pci_vtnet_softc *sc;
 	fd_set rfd;
 
+	pthread_setname_np("net:tap:rx");
+
 	sc = vsc;
 
 	assert(sc);
@@ -488,6 +490,8 @@ pci_vtnet_tx_thread(void *param)
 	struct pci_vtnet_softc *sc = param;
 	struct vqueue_info *vq;
 	int error;
+
+	pthread_setname_np("net:tap:tx");
 
 	vq = &sc->vsc_queues[VTNET_TXQ];
 

--- a/src/pci_virtio_net_vmnet.c
+++ b/src/pci_virtio_net_vmnet.c
@@ -646,6 +646,8 @@ pci_vtnet_tx_thread(void *param)
 	struct vqueue_info *vq;
 	int error;
 
+	pthread_setname_np("net:vmnet:tx");
+
 	vq = &sc->vsc_queues[VTNET_TXQ];
 
 	/*

--- a/src/pci_virtio_net_vpnkit.c
+++ b/src/pci_virtio_net_vpnkit.c
@@ -822,6 +822,8 @@ pci_vtnet_tap_select_func(void *vsc) {
 	struct pci_vtnet_softc *sc;
 	fd_set rfd;
 
+	pthread_setname_np("net:ipc:rx");
+
 	sc = vsc;
 
 	assert(sc);
@@ -916,6 +918,8 @@ pci_vtnet_tx_thread(void *param)
 	struct pci_vtnet_softc *sc = param;
 	struct vqueue_info *vq;
 	int error;
+
+	pthread_setname_np("net:ipc:tx");
 
 	vq = &sc->vsc_queues[VTNET_TXQ];
 

--- a/src/vmm/vmm_callout.c
+++ b/src/vmm/vmm_callout.c
@@ -159,6 +159,8 @@ static void *callout_thread_func(UNUSED void *arg) {
   uint64_t delta, mat;
   int ret;
 
+  pthread_setname_np("callout");
+
   pthread_mutex_lock(&callout_mtx);
 
   while (true) {

--- a/src/xhyve.c
+++ b/src/xhyve.c
@@ -250,10 +250,14 @@ vcpu_thread(void *param)
 	uint64_t rip_entry;
 	int vcpu;
 	int error;
+	char ident[16];
 
 	mtp = param;
 	vcpu = mtp->mt_vcpu;
 	rip_entry = 0xfff0;
+
+	snprintf(ident, sizeof(ident), "vcpu:%d", vcpu);
+	pthread_setname_np(ident);
 
 	error = xh_vcpu_create(vcpu);
 	assert(error == 0);


### PR DESCRIPTION
Only appears to be supported by lldb and "Saved crash reports" today but not
gdb or instruments.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>