### PR TITLE
Introduce simple boot cycle test for hyperkit.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ TARGET = build/com.docker.hyperkit
 
 all: $(TARGET) | build
 
-.PHONY: clean all
+.PHONY: clean all test
 .SUFFIXES:
 
 -include $(DEP)
@@ -148,3 +148,10 @@ $(TARGET): $(TARGET).sym
 
 clean:
 	@rm -rf build
+	@rm -f test/vmlinuz test/initrd.gz
+
+test/vmlinuz test/initrd.gz:
+	@cd test; ./tinycore.sh
+
+test: $(TARGET) test/vmlinuz test/initrd.gz
+	@./test_linux.exp

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,14 @@
+## Testing
+
+Current testing is limited and under development. Proposals should be discussed
+via github issues/pull requests following 
+
+https://docs.docker.com/opensource/workflow/advanced-contributing/
+
+## Expect based test
+
+The current integration test uses expect to drive it. Some tips for diagnosing tests for people new to expect.
+
+* [A basic introductory guide to expect](https://gist.github.com/Fluidbyte/6294378)
+* Turn on internal diagnostics - add `exp_internal 1` to the top of the expect script. This will allow you to see the matches expect is using and how it sees the strings.
+* Interact with a running test - you can use the `interact` to give control of the current process to the user. 

--- a/circle.yml
+++ b/circle.yml
@@ -13,3 +13,4 @@ test:
     - opam install --yes uri qcow-format ocamlfind
     - make clean
     - eval `opam config env` && make all
+    - make test

--- a/test_linux.exp
+++ b/test_linux.exp
@@ -1,0 +1,20 @@
+#!/usr/bin/env expect
+
+set KERNEL "test/vmlinuz"
+set INITRD "test/initrd.gz"
+set CMDLINE "earlyprintk=serial console=ttyS0"
+
+spawn ./build/com.docker.hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -f kexec,$KERNEL,$INITRD,$CMDLINE
+set pid [exp_pid]
+set timeout 20
+
+expect {
+  timeout {puts "FAIL boot"; exec kill -9 $pid; exit 1}
+  "\r\ntc@box:~$ "
+}
+send "sudo halt\r\n";
+expect {
+  timeout {puts "FAIL shutdown"; exec kill -9 $pid; exit 1}
+  "reboot: System halted"
+}
+puts "\n\nPASS"


### PR DESCRIPTION
Fixes #24

Adds dependency on expect, wired in through Makefile.

The expect script replicates the command from hyperkitrun.sh to prevent
requiring a prompt whilst in expect. The dependecy chain is handled in
the Makefile.

Tested both success and failure using make test - adjusting the timeout
to 1 will give an example fail that propgates up to the make return.

Signed-off-by: Pris Nasrat <pnasrat@gmail.com>