### PR TITLE
Minor optimization of tinycore.sh script

### DIFF
--- a/test/tinycore.sh
+++ b/test/tinycore.sh
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -e
 
 # These are binaries from a mirror of
 #  http://tinycorelinux.net
@@ -8,14 +9,15 @@
 
 BASE_URL="http://distro.ibiblio.org/tinycorelinux/"
 
+TMP_DIR=$(mktemp -d)
+INITRD_DIR="${TMP_DIR}"/initrd
+
 echo Downloading tinycore linux
-curl -O -s "${BASE_URL}/6.x/x86/release/distribution_files/vmlinuz64"
-mv vmlinuz64 vmlinuz
-curl -O -s "${BASE_URL}/6.x/x86/release/distribution_files/core.gz"
-mv core.gz initrd.gz
-echo Patching tinycore linux initrd - may prompt for password for sudo
-mkdir initrd
-( cd initrd ; gzcat ../initrd.gz | sudo cpio -idm )
-sudo sed -i -e '/^# ttyS0$/s#^..##' initrd/etc/securetty 
-sudo sed -i -e '/^tty1:/s#tty1#ttyS0#g' initrd/etc/inittab
-( cd initrd ; find . | sudo cpio -o -H newc ) | gzip -c > initrd.gz && sudo rm -rf ./initrd
+curl -s -o vmlinuz "${BASE_URL}/6.x/x86/release/distribution_files/vmlinuz64"
+curl -s -o "${TMP_DIR}"/initrd.gz "${BASE_URL}/6.x/x86/release/distribution_files/core.gz"
+
+mkdir "${INITRD_DIR}"
+( cd "${INITRD_DIR}"; gzip -dc "${TMP_DIR}"/initrd.gz | sudo cpio -idm )
+sudo sed -i -e '/^# ttyS0$/s#^..##' "${INITRD_DIR}"/etc/securetty 
+sudo sed -i -e '/^tty1:/s#tty1#ttyS0#g' "${INITRD_DIR}"/etc/inittab
+( cd "${INITRD_DIR}" ; find . | sudo cpio -o -H newc ) | gzip -c > initrd.gz && sudo rm -rf "${TMP_DIR}"


### PR DESCRIPTION
Optimized the tinycore.sh script:
- Rearranged errexit parameter for sh
- Replace```gzcat``` with ```gzip -dc``` for a better [portability](c9s/perlomni.vim#16)
- Create a temporary directory and do the work within this directory. Easy way to clean up