### PR TITLE
Introduce support for Dtrace static trace points

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build/
+/include/xhyve/dtrace.h
 /test/vmlinuz
 /test/initrd
 /test/initrd.gz

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,12 @@ all: $(TARGET) | build
 build:
 	@mkdir -p build
 
+include/xhyve/dtrace.h: src/dtrace.d
+	@echo gen $<
+	$(VERBOSE) $(DTRACE) -h -s $< -o $@
+
+$(SRC): include/xhyve/dtrace.h
+
 build/%.o: src/%.c
 	@echo cc $<
 	@mkdir -p $(dir $@)
@@ -148,6 +154,7 @@ $(TARGET): $(TARGET).sym
 
 clean:
 	@rm -rf build
+	@rm -f include/xhyve/dtrace.h
 	@rm -f test/vmlinuz test/initrd.gz
 
 test/vmlinuz test/initrd.gz:

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Notes:
 - An explicit older version of sexplib is currently required to build
   qcow format 0.2
 
+## Tracing
+
+HyperKit defines a number of static DTrace probes to simplify investigation of
+performance problems. To list the probes supported by your version of HyperKit,
+type the following command while HyperKit VM is running:
+
+ $ sudo dtrace -l -P 'hyperkit$target' -p $(pgrep hyperkit)
+
+Refer to scripts in dtrace/ directory for examples of possible usage and
+available probes.
 
 ### Relationship to xhyve and bhyve
 

--- a/config.mk
+++ b/config.mk
@@ -18,6 +18,7 @@ AS := clang
 LD := clang
 STRIP := strip
 DSYM := dsymutil
+DTRACE := dtrace
 
 ENV := \
   LANG=en_US.US-ASCII
@@ -36,6 +37,7 @@ CFLAGS_WARN := \
   -Werror \
   -Wno-unknown-warning-option \
   -Wno-reserved-id-macro \
+  -Wno-dollar-in-identifier-extension \
   -pedantic
 
 CFLAGS_DIAG := \

--- a/config.mk
+++ b/config.mk
@@ -38,6 +38,7 @@ CFLAGS_WARN := \
   -Wno-unknown-warning-option \
   -Wno-reserved-id-macro \
   -Wno-dollar-in-identifier-extension \
+  -Wno-gnu-statement-expression \
   -pedantic
 
 CFLAGS_DIAG := \

--- a/dtrace/eptfault.d
+++ b/dtrace/eptfault.d
@@ -1,0 +1,24 @@
+#!/usr/sbin/dtrace -s
+/*
+ * eptfault.d - report all EPT faults for particular VM
+ *
+ * USAGE: eptfault.d -p <pid of com.docker.hyperkit>
+ */
+
+#pragma D option quiet
+
+dtrace:::BEGIN
+{
+	printf("Tracing... Hit Ctrl-C to end.\n");
+}
+
+hyperkit$target:::vmx-ept-fault
+{
+	@num[arg1, arg0] = count();
+}
+
+dtrace:::END
+{
+	printf("%18s %-4s %8s\n", "ADDRESS", "vCPU", "COUNT");
+	printa("%18x %-4d %@8d\n", @num);
+}

--- a/dtrace/vmxexit.d
+++ b/dtrace/vmxexit.d
@@ -1,0 +1,81 @@
+#!/usr/sbin/dtrace -s
+/*
+ * vmxexit.d - report all VMX exits for particular VM
+ *
+ * USAGE: vmxexit.d -p <pid of com.docker.hyperkit>
+ */
+
+#pragma D option quiet
+
+string reasons[int];
+
+dtrace:::BEGIN
+{
+	reasons[0]  = "EXCEPTION";
+	reasons[1]  = "EXT_INTR";
+	reasons[2]  = "TRIPLE_FAULT";
+	reasons[3]  = "INIT";
+	reasons[4]  = "SIPI";
+	reasons[5]  = "IO_SMI";
+	reasons[6]  = "SMI";
+	reasons[7]  = "INTR_WINDOW";
+	reasons[8]  = "NMI_WINDOW";
+	reasons[9]  = "TASK_SWITCH";
+	reasons[10] = "CPUID";
+	reasons[11] = "GETSEC";
+	reasons[12] = "HLT";
+	reasons[13] = "INVD";
+	reasons[14] = "INVLPG";
+	reasons[15] = "RDPMC";
+	reasons[16] = "RDTSC";
+	reasons[17] = "RSM";
+	reasons[18] = "VMCALL";
+	reasons[19] = "VMCLEAR";
+	reasons[20] = "VMLAUNCH";
+	reasons[21] = "VMPTRLD";
+	reasons[22] = "VMPTRST";
+	reasons[23] = "VMREAD";
+	reasons[24] = "VMRESUME";
+	reasons[25] = "VMWRITE";
+	reasons[26] = "VMXOFF";
+	reasons[27] = "VMXON";
+	reasons[28] = "CR_ACCESS";
+	reasons[29] = "DR_ACCESS";
+	reasons[30] = "INOUT";
+	reasons[31] = "RDMSR";
+	reasons[32] = "WRMSR";
+	reasons[33] = "INVAL_VMCS";
+	reasons[34] = "INVAL_MSR";
+	reasons[36] = "MWAIT";
+	reasons[37] = "MTF";
+	reasons[39] = "MONITOR";
+	reasons[40] = "PAUSE";
+	reasons[41] = "MCE_DURING_ENTRY";
+	reasons[43] = "TPR";
+	reasons[44] = "APIC_ACCESS";
+	reasons[45] = "VIRTUALIZED_EOI";
+	reasons[46] = "GDTR_IDTR";
+	reasons[47] = "LDTR_TR";
+	reasons[48] = "EPT_FAULT";
+	reasons[49] = "EPT_MISCONFIG";
+	reasons[50] = "INVEPT";
+	reasons[51] = "RDTSCP";
+	reasons[52] = "VMX_PREEMPT";
+	reasons[53] = "INVVPID";
+	reasons[54] = "WBINVD";
+	reasons[55] = "XSETBV";
+	reasons[56] = "APIC_WRITE";
+
+	printf("Tracing... Hit Ctrl-C to end.\n");
+}
+
+hyperkit$target:::vmx-exit
+{
+	@num[reasons[arg1], arg0] = count();
+}
+
+dtrace:::END
+{
+	printf("%16s %-4s %8s\n", "REASON", "vCPU", "COUNT");
+	printa("%16s %-4d %@8d\n", @num);
+}

--- a/src/dtrace.d
+++ b/src/dtrace.d
@@ -2,4 +2,6 @@ provider hyperkit {
 	probe vmx__exit(int, unsigned int);
 	probe vmx__ept__fault(int, unsigned long, unsigned long);
 	probe vmx__inject__virq(int, int);
+	probe vmx__write__msr(int, unsigned int, unsigned long);
+	probe vmx__read__msr(int, unsigned int, unsigned long);
 };

--- a/src/dtrace.d
+++ b/src/dtrace.d
@@ -4,4 +4,9 @@ provider hyperkit {
 	probe vmx__inject__virq(int, int);
 	probe vmx__write__msr(int, unsigned int, unsigned long);
 	probe vmx__read__msr(int, unsigned int, unsigned long);
+
+	probe block__preadv(off_t, size_t);
+	probe block__preadv__done(off_t, ssize_t);
+	probe block__pwritev(off_t, size_t);
+	probe block__pwritev__done(off_t, ssize_t);
 };

--- a/src/dtrace.d
+++ b/src/dtrace.d
@@ -1,2 +1,5 @@
 provider hyperkit {
+	probe vmx__exit(int, unsigned int);
+	probe vmx__ept__fault(int, unsigned long, unsigned long);
+	probe vmx__inject__virq(int, int);
 };

--- a/src/dtrace.d
+++ b/src/dtrace.d
@@ -1,0 +1,2 @@
+provider hyperkit {
+};


### PR DESCRIPTION
This pull request adds all the build system bits needed to support static DTrace trace points and defines one sample trace point as an example.

DTrace provides a great ability to dig inside a running system with little to none overhead and will be of great help during performance investigations.

Example usage is shown in the second commit message.