### PR TITLE
Updated OSSpinLock for Sierra

### DIFF
--- a/include/xhyve/support/platform_locks.h
+++ b/include/xhyve/support/platform_locks.h
@@ -26,7 +26,7 @@
 
 #include <Availability.h>
 
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1012
 #define XHYVE_USE_OSLOCKS 1
 #include <os/lock.h>
 #else

--- a/include/xhyve/support/platform_locks.h
+++ b/include/xhyve/support/platform_locks.h
@@ -1,0 +1,34 @@
+/*-
+ * Copyright (c) 2016 Anil Madhavapeddy <anil@recoil.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <Availability.h>
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_12
+#define XHYVE_USE_OSLOCKS 1
+#include <os/lock.h>
+#else
+#include <libkern/OSAtomic.h>
+#endif

--- a/include/xhyve/vmm/io/vlapic_priv.h
+++ b/include/xhyve/vmm/io/vlapic_priv.h
@@ -30,10 +30,9 @@
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <libkern/OSAtomic.h>
 #include <xhyve/support/apicreg.h>
 #include <xhyve/vmm/vmm_callout.h>
-#include <os/lock.h>
+#include <xhyve/support/platform_locks.h>
 
 /*
  * APIC Register:		Offset	   Description
@@ -164,7 +163,11 @@ struct vlapic {
 	struct bintime timer_fire_bt; /* callout expiry time */
 	struct bintime timer_freq_bt; /* timer frequency */
 	struct bintime timer_period_bt; /* timer period */
+#ifdef XHYVE_USE_OSLOCKS
 	os_unfair_lock timer_lock;
+#else
+	OSSpinLock timer_lock;
+#endif
 	/*
 	 * The 'isrvec_stk' is a stack of vectors injected by the local apic.
 	 * A vector is popped from the stack when the processor does an EOI.

--- a/include/xhyve/vmm/io/vlapic_priv.h
+++ b/include/xhyve/vmm/io/vlapic_priv.h
@@ -33,6 +33,7 @@
 #include <libkern/OSAtomic.h>
 #include <xhyve/support/apicreg.h>
 #include <xhyve/vmm/vmm_callout.h>
+#include <os/lock.h>
 
 /*
  * APIC Register:		Offset	   Description
@@ -163,7 +164,7 @@ struct vlapic {
 	struct bintime timer_fire_bt; /* callout expiry time */
 	struct bintime timer_freq_bt; /* timer frequency */
 	struct bintime timer_period_bt; /* timer period */
-	OSSpinLock timer_lock;
+	os_unfair_lock timer_lock;
 	/*
 	 * The 'isrvec_stk' is a stack of vectors injected by the local apic.
 	 * A vector is popped from the stack when the processor does an EOI.

--- a/src/vmm/io/vatpic.c
+++ b/src/vmm/io/vatpic.c
@@ -788,9 +788,9 @@ vatpic_init(struct vm *vm)
 	assert(vatpic);
 	bzero(vatpic, sizeof(struct vatpic));
 	vatpic->vm = vm;
-
-	// VATPIC_LOCK_INIT(vatpic);
-
+#ifndef XHYVE_USE_OSLOCKS
+	VATPIC_LOCK_INIT(vatpic);
+#endif
 	return (vatpic);
 }
 

--- a/src/vmm/io/vatpic.c
+++ b/src/vmm/io/vatpic.c
@@ -29,7 +29,6 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <assert.h>
-
 #include <libkern/OSAtomic.h>
 #include <xhyve/support/misc.h>
 #include <xhyve/support/i8259.h>

--- a/src/vmm/io/vatpit.c
+++ b/src/vmm/io/vatpit.c
@@ -90,11 +90,11 @@ struct channel {
 
 struct vatpit {
 	struct vm *vm;
-	#ifdef XHYVE_USE_OSLOCKS
-    os_unfair_lock lock;
-  #else
-    OSSpinLock lock;
-  #endif
+#ifdef XHYVE_USE_OSLOCKS
+  os_unfair_lock lock;
+#else
+  OSSpinLock lock;
+#endif
 	sbintime_t freq_sbt;
 	struct channel channel[3];
 };
@@ -431,9 +431,9 @@ vatpit_init(struct vm *vm)
 	assert(vatpit);
 	bzero(vatpit, sizeof(struct vatpit));
 	vatpit->vm = vm;
-
-	// VATPIT_LOCK_INIT(vatpit)
-
+#ifndef XHYVE_USE_OSLOCKS
+	VATPIT_LOCK_INIT(vatpit)
+#endif
 	FREQ2BT(PIT_8254_FREQ, &bt);
 	vatpit->freq_sbt = bttosbt(bt);
 

--- a/src/vmm/io/vioapic.c
+++ b/src/vmm/io/vioapic.c
@@ -49,11 +49,11 @@
 #pragma clang diagnostic ignored "-Wpadded"
 struct vioapic {
 	struct vm *vm;
-	#ifdef XHYVE_USE_OSLOCKS
-    os_unfair_lock lock;
-  #else
-    OSSpinLock lock;
-  #endif
+#ifdef XHYVE_USE_OSLOCKS
+  os_unfair_lock lock;
+#else
+  OSSpinLock lock;
+#endif
 	uint32_t id;
 	uint32_t ioregsel;
 	struct {
@@ -469,9 +469,9 @@ vioapic_init(struct vm *vm)
 	assert(vioapic);
 	bzero(vioapic, sizeof(struct vioapic));
 	vioapic->vm = vm;
-
-	// VIOAPIC_LOCK_INIT(vioapic);
-
+#ifndef XHYVE_USE_OSLOCKS
+	VIOAPIC_LOCK_INIT(vioapic);
+#endif
 	/* Initialize all redirection entries to mask all interrupts */
 	for (i = 0; i < REDIR_ENTRIES; i++)
 		vioapic->rtbl[i].reg = 0x0001000000010000UL;

--- a/src/vmm/io/vioapic.c
+++ b/src/vmm/io/vioapic.c
@@ -32,6 +32,7 @@
 #include <stdbool.h>
 #include <errno.h>
 #include <assert.h>
+#include <os/lock.h>
 #include <libkern/OSAtomic.h>
 #include <xhyve/support/misc.h>
 #include <xhyve/support/apicreg.h>
@@ -49,7 +50,7 @@
 #pragma clang diagnostic ignored "-Wpadded"
 struct vioapic {
 	struct vm *vm;
-	OSSpinLock lock;
+	os_unfair_lock lock;
 	uint32_t id;
 	uint32_t ioregsel;
 	struct {
@@ -59,9 +60,9 @@ struct vioapic {
 };
 #pragma clang diagnostic pop
 
-#define VIOAPIC_LOCK_INIT(v) (v)->lock = OS_SPINLOCK_INIT;
-#define VIOAPIC_LOCK(v) OSSpinLockLock(&(v)->lock)
-#define VIOAPIC_UNLOCK(v) OSSpinLockUnlock(&(v)->lock)
+// #define VIOAPIC_LOCK_INIT(v) (v)->lock = OS_SPINLOCK_INIT;
+#define VIOAPIC_LOCK(v) os_unfair_lock_lock(&(v)->lock)
+#define VIOAPIC_UNLOCK(v) os_unfair_lock_unlock(&(v)->lock)
 
 #define	VIOAPIC_CTR1(vioapic, fmt, a1) \
 	VM_CTR1((vioapic)->vm, fmt, a1)
@@ -461,7 +462,7 @@ vioapic_init(struct vm *vm)
 	bzero(vioapic, sizeof(struct vioapic));
 	vioapic->vm = vm;
 
-	VIOAPIC_LOCK_INIT(vioapic);
+	// VIOAPIC_LOCK_INIT(vioapic);
 
 	/* Initialize all redirection entries to mask all interrupts */
 	for (i = 0; i < REDIR_ENTRIES; i++)

--- a/src/vmm/io/vlapic.c
+++ b/src/vmm/io/vlapic.c
@@ -31,6 +31,7 @@
 #include <stdbool.h>
 #include <strings.h>
 #include <errno.h>
+#include <os/lock.h>
 #include <xhyve/support/misc.h>
 #include <xhyve/support/atomic.h>
 #include <xhyve/support/specialreg.h>
@@ -56,9 +57,9 @@
  * - timer_freq_bt, timer_period_bt, timer_fire_bt
  * - timer LVT register
  */
-#define VLAPIC_TIMER_LOCK_INIT(v) (v)->timer_lock = OS_SPINLOCK_INIT;
-#define VLAPIC_TIMER_LOCK(v) OSSpinLockLock(&(v)->timer_lock)
-#define VLAPIC_TIMER_UNLOCK(v) OSSpinLockUnlock(&(v)->timer_lock)
+// #define VLAPIC_TIMER_LOCK_INIT(v) (v)->timer_lock = OS_SPINLOCK_INIT;
+#define VLAPIC_TIMER_LOCK(v) os_unfair_lock_lock(&(v)->timer_lock)
+#define VLAPIC_TIMER_UNLOCK(v) os_unfair_lock_unlock(&(v)->timer_lock)
 
 /*
  * APIC timer frequency:
@@ -136,7 +137,7 @@ void
 vlapic_id_write_handler(struct vlapic *vlapic)
 {
 	struct LAPIC *lapic;
-	
+
 	/*
 	 * We don't allow the ID register to be modified so reset it back to
 	 * its default value.
@@ -186,7 +187,7 @@ vlapic_get_ccr(struct vlapic *vlapic)
 	struct bintime bt_now, bt_rem;
 	struct LAPIC *lapic;
 	uint32_t ccr;
-	
+
 	ccr = 0;
 	lapic = vlapic->apic_page;
 
@@ -217,7 +218,7 @@ vlapic_dcr_write_handler(struct vlapic *vlapic)
 {
 	struct LAPIC *lapic;
 	int divisor;
-	
+
 	lapic = vlapic->apic_page;
 	VLAPIC_TIMER_LOCK(vlapic);
 
@@ -242,7 +243,7 @@ void
 vlapic_esr_write_handler(struct vlapic *vlapic)
 {
 	struct LAPIC *lapic;
-	
+
 	lapic = vlapic->apic_page;
 	lapic->esr = vlapic->esr_pending;
 	vlapic->esr_pending = 0;
@@ -371,9 +372,9 @@ vlapic_lvt_write_handler(struct vlapic *vlapic, uint32_t offset)
 	uint32_t *lvtptr, mask, val;
 	struct LAPIC *lapic;
 	int idx;
-	
+
 	lapic = vlapic->apic_page;
-	lvtptr = vlapic_get_lvtptr(vlapic, offset);	
+	lvtptr = vlapic_get_lvtptr(vlapic, offset);
 	val = *lvtptr;
 	idx = lvt_off_to_idx(offset);
 
@@ -593,7 +594,7 @@ static __inline int
 vlapic_periodic_timer(struct vlapic *vlapic)
 {
 	uint32_t lvt;
-	
+
 	lvt = vlapic_get_lvt(vlapic, APIC_OFFSET_TIMER_LVT);
 
 	return (vlapic_get_lvt_field(lvt, APIC_LVTT_TM_PERIODIC));
@@ -625,7 +626,7 @@ static void
 vlapic_fire_timer(struct vlapic *vlapic)
 {
 	uint32_t lvt;
-	
+
 	// The timer LVT always uses the fixed delivery mode.
 	lvt = vlapic_get_lvt(vlapic, APIC_OFFSET_TIMER_LVT);
 	if (vlapic_fire_lvt(vlapic, lvt | APIC_LVT_DM_FIXED)) {
@@ -804,7 +805,7 @@ vlapic_icrtmr_write_handler(struct vlapic *vlapic)
 /*
  * This function populates 'dmask' with the set of vcpus that match the
  * addressing specified by the (dest, phys, lowprio) tuple.
- * 
+ *
  * 'x2apic_dest' specifies whether 'dest' is interpreted as x2APIC (32-bit)
  * or xAPIC (8-bit) destination field.
  */
@@ -1102,7 +1103,7 @@ vlapic_pending_intr(struct vlapic *vlapic, int *vecptr)
 				if (vecptr != NULL)
 					*vecptr = vector;
 				return (1);
-			} else 
+			} else
 				break;
 		}
 	}
@@ -1122,7 +1123,7 @@ vlapic_intr_accepted(struct vlapic *vlapic, int vector)
 	}
 
 	/*
-	 * clear the ready bit for vector being accepted in irr 
+	 * clear the ready bit for vector being accepted in irr
 	 * and set the vector as in service in isr.
 	 */
 	idx = (vector / 32) * 4;
@@ -1214,7 +1215,7 @@ vlapic_read(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 		*data = 0;
 		goto done;
 	}
-	
+
 	offset &= ~((uint64_t) 3);
 	switch(offset)
 	{
@@ -1284,12 +1285,12 @@ vlapic_read(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 		case APIC_OFFSET_ESR:
 			*data = lapic->esr;
 			break;
-		case APIC_OFFSET_ICR_LOW: 
+		case APIC_OFFSET_ICR_LOW:
 			*data = lapic->icr_lo;
 			if (x2apic(vlapic))
 				*data |= (uint64_t)lapic->icr_hi << 32;
 			break;
-		case APIC_OFFSET_ICR_HI: 
+		case APIC_OFFSET_ICR_HI:
 			*data = lapic->icr_hi;
 			break;
 		case APIC_OFFSET_CMCI_LVT:
@@ -1299,7 +1300,7 @@ vlapic_read(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 		case APIC_OFFSET_LINT0_LVT:
 		case APIC_OFFSET_LINT1_LVT:
 		case APIC_OFFSET_ERROR_LVT:
-			*data = vlapic_get_lvt(vlapic, ((uint32_t) offset));	
+			*data = vlapic_get_lvt(vlapic, ((uint32_t) offset));
 #ifdef INVARIANTS
 			reg = vlapic_get_lvtptr(vlapic, offset);
 			KASSERT(*data == *reg, ("inconsistent lvt value at "
@@ -1389,7 +1390,7 @@ vlapic_write(struct vlapic *vlapic, int mmio_access, uint64_t offset,
 			lapic->svr = (uint32_t) data;
 			vlapic_svr_write_handler(vlapic);
 			break;
-		case APIC_OFFSET_ICR_LOW: 
+		case APIC_OFFSET_ICR_LOW:
 			lapic->icr_lo = (uint32_t) data;
 			if (x2apic(vlapic))
 				lapic->icr_hi = data >> 32;
@@ -1469,7 +1470,7 @@ static void
 vlapic_reset(struct vlapic *vlapic)
 {
 	struct LAPIC *lapic;
-	
+
 	lapic = vlapic->apic_page;
 	bzero(lapic, sizeof(struct LAPIC));
 
@@ -1508,7 +1509,7 @@ vlapic_init(struct vlapic *vlapic)
 	 * Therefore the timer mutex must be a spinlock because blockable
 	 * mutexes cannot be acquired in a critical section.
 	 */
-	VLAPIC_TIMER_LOCK_INIT(vlapic);
+	// VLAPIC_TIMER_LOCK_INIT(vlapic);
 	callout_init(&vlapic->callout, 1);
 
 	vlapic->msr_apicbase = DEFAULT_APIC_BASE | APICBASE_ENABLED;

--- a/src/vmm/io/vlapic.c
+++ b/src/vmm/io/vlapic.c
@@ -1510,7 +1510,9 @@ vlapic_init(struct vlapic *vlapic)
 	 * Therefore the timer mutex must be a spinlock because blockable
 	 * mutexes cannot be acquired in a critical section.
 	 */
-	// VLAPIC_TIMER_LOCK_INIT(vlapic);
+#ifndef XHYVE_USE_OSLOCKS
+	VLAPIC_TIMER_LOCK_INIT(vlapic);
+#endif
 	callout_init(&vlapic->callout, 1);
 
 	vlapic->msr_apicbase = DEFAULT_APIC_BASE | APICBASE_ENABLED;

--- a/src/vmm/vmm.c
+++ b/src/vmm/vmm.c
@@ -69,11 +69,11 @@ struct vlapic;
  * (x) initialized before use
  */
 struct vcpu {
-	#ifdef XHYVE_USE_OSLOCKS
-    os_unfair_lock lock;
-  #else
-    OSSpinLock timer_lock;
-  #endif
+#ifdef XHYVE_USE_OSLOCKS
+  os_unfair_lock lock;
+#else
+  OSSpinLock timer_lock;
+#endif
 	pthread_mutex_t state_sleep_mtx;
 	pthread_cond_t state_sleep_cnd;
 	pthread_mutex_t vcpu_sleep_mtx;
@@ -213,7 +213,9 @@ vcpu_init(struct vm *vm, int vcpu_id, bool create)
 	vcpu = &vm->vcpu[vcpu_id];
 
 	if (create) {
-    // vcpu_lock_init(vcpu);
+  #ifndef XHYVE_USE_OSLOCKS
+    vcpu_lock_init(vcpu);
+  #endif
 		pthread_mutex_init(&vcpu->state_sleep_mtx, NULL);
 		pthread_cond_init(&vcpu->state_sleep_cnd, NULL);
 		pthread_mutex_init(&vcpu->vcpu_sleep_mtx, NULL);


### PR DESCRIPTION
While trying to build hyperkit on Sierra (beta 3) - it would throw on `OSSpinLock` - and the error messages suggested it should be replaced with `os_unfair_lock`. So, I replaced the OSSpinLock with the `os_unfair` equivalents  - commented out the `OS_SPINLOCK_INIT` methods, and  It passed the test and works. Here's the  [os API](https://developer.apple.com/reference/os) for reference (doesn't say anything). 

Docker is unusable without disabling the `ntpd` `daemon` - `sudo launchctl unload /System/Library/LaunchDaemons/org.ntp.ntpd.plist` - after that it works perfectly. So I thought that the vmnet / xhyve layer wasn't able to communicate with the system clocks. While testing hyperkit, it has this error message:

````
ACPI Error: Could not enable RealTimeClock event ....
ACPI Warning: Could not enable fixed event - RealTimeClock ....
````

It seems like ACPI  is already a known issue - and the test ended with `PASS`. But while researching why OSSpinLock was depreciated, I ran into. a few articles that made me think it should be replaced and may even be contributing to poor network performance on 10.10+. Webkit wrote a [blogpost](https://webkit.org/blog/6161/locking-in-webkit/) about why they replaced all spinlocks and os-provided-mutexes:

> Compared to OS-provided locks like pthread_mutex, WTF::Lock is 64 times smaller and up to 180 times faster. Compared to OS-provided condition variables like pthread_cond, WTF::Condition is 64 times smaller. Using WTF::Lock instead of pthread_mutex means that WebKit is 10% faster on JetStream, 5% faster on Speedometer, and 5% faster on our page loading test.

I mentioned it in [this issue](https://github.com/docker/hyperkit/issues/47) - and it was pretty simple to implement - but this pull request is meant to raise awareness. I don't know if this method is backwards compatibility < 10.12 - or if they're going to patch 10.10+ to implement this - so it shouldn't be pulled into the main branch. I have not been able to confirm  whether or not OSSpinLock is  potentially effecting the entire hypervisor app - but I haven't seen this discussed anywhere in relation to docker - just wanted to bring it someone's attention.