### PR TITLE
fixed make test failure in osx 10.10.5 - see https://github.com/docker/hyperkit/issues/52

### DIFF
--- a/test/tinycore.sh
+++ b/test/tinycore.sh
@@ -9,7 +9,7 @@ set -e
 
 BASE_URL="http://distro.ibiblio.org/tinycorelinux/"
 
-TMP_DIR=$(mktemp -d)
+TMP_DIR=$(mktemp -d -t hyperkit)
 INITRD_DIR="${TMP_DIR}"/initrd
 
 echo Downloading tinycore linux


### PR DESCRIPTION
make test was failing due to the mktemp variation in osx 10.10.5