### PR TITLE
Update virt-sock backend to v7 spec

### DIFF
--- a/src/pci_virtio_sock.c
+++ b/src/pci_virtio_sock.c
@@ -67,6 +67,11 @@
 #define VTSOCK_MAXSOCKS	1024
 #define VTSOCK_MAXFWDS	4
 
+/* Number of seconds to wait after sending an OP_SHUTDOWN flags == ALL before
+ * we RST the connection ourselves.
+ */
+#define SHUTDOWN_RST_DELAY	30
+
 /*
  * Host capabilities
  */
@@ -248,6 +253,7 @@ struct pci_vtsock_sock {
 	uint16_t port_generation;
 	/* valid when SOCK_CONNECTED only */
 	uint32_t local_shutdown, peer_shutdown;
+	time_t rst_deadline; /* When local_shutdown==ALL, expect RST before */
 
 	struct vsock_addr local_addr;
 	struct vsock_addr peer_addr;
@@ -768,7 +774,7 @@ static void kick_tx(struct pci_vtsock_softc *sc, const char *why)
 }
 
 /* Reflect peer_shutdown into local fd */
-static uint32_t shutdown_peer_local_fd(struct pci_vtsock_sock *s, uint32_t mode,
+static void shutdown_peer_local_fd(struct pci_vtsock_sock *s, uint32_t mode,
 				       const char *ctx)
 {
 	int rc;
@@ -785,7 +791,7 @@ static uint32_t shutdown_peer_local_fd(struct pci_vtsock_sock *s, uint32_t mode,
 
 	switch (set) {
 	case 0:
-		return 0;
+		return;
 	case VIRTIO_VSOCK_FLAG_SHUTDOWN_TX:
 		how = SHUT_WR;
 		how_str = "SHUT_WR";
@@ -811,7 +817,6 @@ static uint32_t shutdown_peer_local_fd(struct pci_vtsock_sock *s, uint32_t mode,
 	}
 
 	s->peer_shutdown = new;
-	return set;
 }
 
 /* The caller must have sent something (probably OP_RST, but perhaps
@@ -848,55 +853,18 @@ static void close_sock_rx(struct pci_vtsock_softc *sc,  struct pci_vtsock_sock *
 	close_sock_common(sc, s, "RX", SOCK_CLOSING_TX, &kick_tx);
 }
 
-/* Only to be called from the TX thread */
-static void shutdown_peer_sock_tx(struct pci_vtsock_softc *sc, struct pci_vtsock_sock *s,
-				  uint32_t mode)
-{
-	const char *ctx = "TX";
-	bool kick = false;
-	uint32_t set;
-
-	assert(pthread_self() == sc->tx_thread);
-	assert((mode & ~VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL) == 0);
-
-	if (s->state != SOCK_CONNECTED) goto done;
-
-	assert(s->local_shutdown != VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL);
-
-	DPRINTF(("%s: fd %d: PEER SHUTDOWN 0x%"PRIx32" (0x%"PRIx32")\n",
-		 ctx, s->fd, mode, s->peer_shutdown));
-
-	set = shutdown_peer_local_fd(s, mode, ctx);
-
-	DPRINTF(("%s: setting 0x%"PRIx32" mode is now 0x%"PRIx32" (local 0x%"PRIx32")\n",
-		 ctx, set, s->peer_shutdown, s->local_shutdown));
-
-	/* Is everything now closed? */
-	if (/*set &&*/ mode == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL &&
-	    /*s->local_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL &&*/
-	    s->peer_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL) {
-		s->state = SOCK_CLOSING_RX;
-		kick = true;
-	}
-
-done:
-	if (kick) kick_rx(sc, "shutdown (peer)");
-}
-
 /*
  * Caller should send OP_SHUTDOWN with flags == s->local_shutdown after calling this.
- * Only to be called from the RX thread.
  */
 static void shutdown_local_sock(const char *ctx,
-				struct pci_vtsock_softc *sc, struct pci_vtsock_sock *s,
+				struct pci_vtsock_sock *s,
 				uint32_t mode)
 {
-	bool kick = false;
 	uint32_t new, set;
 
 	assert((mode & ~VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL) == 0);
 
-	if (s->state != SOCK_CONNECTED) goto done;
+	if (s->state != SOCK_CONNECTED) return;
 
 	assert(s->local_shutdown != VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL);
 
@@ -910,16 +878,8 @@ static void shutdown_local_sock(const char *ctx,
 	DPRINTF(("%s: setting 0x%"PRIx32" mode is now 0x%"PRIx32" (peer 0x%"PRIx32")\n",
 		 ctx, set, s->local_shutdown, s->peer_shutdown));
 
-	/* Did we do something and is everything now closed? */
-	if (set &&
-	    s->local_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL /*&&
-	    s->peer_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL*/) {
-		s->state = SOCK_CLOSING_TX;
-		kick = true;
-	}
-
-done:
-	if (kick) kick_tx(sc, "shutdown (local)");
+	if (s->local_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL)
+		s->rst_deadline = time(NULL) + SHUTDOWN_RST_DELAY;
 }
 
 static void set_credit_update_required(struct pci_vtsock_softc *sc,
@@ -1044,7 +1004,7 @@ static void buffer_drain(struct pci_vtsock_softc *sc,
 	if (nr == -1) {
 		if (errno == EPIPE) {
 			/* Assume EOF and shutdown */
-			shutdown_local_sock("TX", sc, sock, VIRTIO_VSOCK_FLAG_SHUTDOWN_RX);
+			shutdown_local_sock("TX", sock, VIRTIO_VSOCK_FLAG_SHUTDOWN_RX);
 			send_response_sock(sc, VIRTIO_VSOCK_OP_SHUTDOWN,
 					   sock->local_shutdown, sock);
 			return;
@@ -1095,7 +1055,7 @@ static int handle_write(struct pci_vtsock_softc *sc,
 		if (errno == EPIPE) {
 			/* Assume EOF and shutdown */
 			PPRINTF(("TX: writev fd=%d failed with EPIPE => SHUTDOWN_RX\n", sock->fd));
-			shutdown_local_sock("TX", sc, sock, VIRTIO_VSOCK_FLAG_SHUTDOWN_RX);
+			shutdown_local_sock("TX", sock, VIRTIO_VSOCK_FLAG_SHUTDOWN_RX);
 			send_response_sock(sc, VIRTIO_VSOCK_OP_SHUTDOWN,
 					   sock->local_shutdown, sock);
 			return 0;
@@ -1260,7 +1220,13 @@ static void pci_vtsock_proc_tx(struct pci_vtsock_softc *sc,
 			goto do_rst; /* ??? */
 		}
 
-		shutdown_peer_sock_tx(sc, sock, hdr.flags);
+		shutdown_peer_local_fd(sock, hdr.flags, "TX");
+
+		/* If the peer is now SHUTDOWN_ALL then we should send
+		 * a RST to the peer to finalise the shutdown.
+		 */
+		if (sock->peer_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL)
+			goto do_rst;
 
 		vq_relchain(vq, idx, 0);
 		break;
@@ -1468,6 +1434,7 @@ static void *pci_vtsock_tx_thread(void *vsc)
 		int i, nrfd, maxfd, nr;
 		int buffering = 0;
 		struct pci_vtsock_sock *s;
+		struct timeval *select_timeout = NULL, select_timeout_5s;
 
 		LIST_INIT(&queue);
 
@@ -1518,6 +1485,23 @@ static void *pci_vtsock_tx_thread(void *vsc)
 				continue;
 			}
 			assert(s->fd >= 0);
+
+			if (s->local_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL) {
+				time_t now = time(NULL);
+
+				/* Has deadline for peer to return a RST expired? */
+				if (now > s->rst_deadline) {
+					send_response_sock(sc, VIRTIO_VSOCK_OP_RST, 0, s);
+					close_sock_tx(sc, s);
+					put_sock(s);
+					continue;
+				} else if (select_timeout == NULL) {
+					select_timeout_5s.tv_sec = 5;
+					select_timeout_5s.tv_usec = 0;
+					select_timeout = &select_timeout_5s;
+				}
+			}
+
 			if (sock_is_buffering(s)) {
 				FD_SET(s->fd, &wfd);
 				maxfd = max_fd(s->fd, maxfd);
@@ -1535,7 +1519,7 @@ static void *pci_vtsock_tx_thread(void *vsc)
 
 		DPRINTF(("TX: *** selecting on %d fds (buffering: %d)\n",
 			 nrfd, buffering));
-		nr = xselect("TX", maxfd + 1, &rfd, &wfd, NULL, NULL);
+		nr = xselect("TX", maxfd + 1, &rfd, &wfd, NULL, select_timeout);
 		if (nr < 0) continue;
 		DPRINTF(("TX:\nTX: *** %d/%d fds are readable/writeable\n", nr, nrfd));
 
@@ -1673,7 +1657,7 @@ static ssize_t pci_vtsock_proc_rx(struct pci_vtsock_softc *sc,
 	DPRINTF(("RX: readv put %zd bytes into iov\n", len));
 	if (len == 0) { /* Not actually anything to read -- EOF */
 		PPRINTF(("RX: readv fd=%d EOF => SHUTDOWN_TX\n", s->fd));
-		shutdown_local_sock("RX", sc, s, VIRTIO_VSOCK_FLAG_SHUTDOWN_TX);
+		shutdown_local_sock("RX", s, VIRTIO_VSOCK_FLAG_SHUTDOWN_TX);
 		hdr->op = VIRTIO_VSOCK_OP_SHUTDOWN;
 		hdr->flags = s->local_shutdown;
 		hdr->len = 0;


### PR DESCRIPTION
V7 spec was posted to the virtio-spec list in <1470324277-19300-1-git-send-email-stefanha@redhat.com>.

This requires a corresponding update to the Linux frontend to the v6 RFC patches posted as <1469716595-13591-1-git-send-email-stefanha@redhat.com>. These have also been merged into Linux v4.8-rc1.

This should hopefully fix docker/hyperkit#50.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>