### PR TITLE
Open block devices using the `Block.Config` interface

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ test:
     - brew install opam
     - opam init --yes
     - opam pin add qcow-format git://github.com/mirage/ocaml-qcow#master --yes
+    - opam pin add mirage-block-unix git://github.com/mirage/mirage-block-unix#master --yes
     - opam install --yes uri qcow-format ocamlfind
     - make clean
     - eval `opam config env` && make all

--- a/src/block_if.c
+++ b/src/block_if.c
@@ -576,7 +576,7 @@ blockif_open(const char *optstr, const char *ident)
 	if (use_mirage) {
 #ifdef HAVE_OCAML_QCOW
 		mirage_block_register_thread();
-		mbh = mirage_block_open(nopt, 1);
+		mbh = mirage_block_open(nopt);
 		if (mbh < 0) {
 			perror("Could not open mirage-block device");
 			goto err;

--- a/src/mirage_block_c.c
+++ b/src/mirage_block_c.c
@@ -46,13 +46,12 @@ if (fn == NULL) { \
 	acquiring the runtime lock. */
 
 static void
-ocaml_mirage_block_open(const char *uri, int buffered, int *out, int *err) {
+ocaml_mirage_block_open(const char *config, int *out, int *err) {
 	CAMLparam0();
-	CAMLlocal3(ocaml_uri, ocaml_buffered, handle);
-	ocaml_uri = caml_copy_string(uri);
-	ocaml_buffered = Val_bool(buffered);
+	CAMLlocal2(ocaml_config, handle);
+	ocaml_config = caml_copy_string(config);
 	OCAML_NAMED_FUNCTION("mirage_block_open")
-	handle = caml_callback2_exn(*fn, ocaml_uri, ocaml_buffered);
+	handle = caml_callback_exn(*fn, ocaml_config);
 	if (Is_exception_result(handle)){
 		*err = 1;
 	} else {
@@ -63,11 +62,11 @@ ocaml_mirage_block_open(const char *uri, int buffered, int *out, int *err) {
 }
 
 mirage_block_handle
-mirage_block_open(const char *uri, int buffered) {
+mirage_block_open(const char *config) {
 	int result;
 	int err = 1;
 	caml_acquire_runtime_system();
-	ocaml_mirage_block_open(uri, buffered, &result, &err);
+	ocaml_mirage_block_open(config, &result, &err);
 	caml_release_runtime_system();
 	if (err){
 		errno = EINVAL;

--- a/src/mirage_block_c.h
+++ b/src/mirage_block_c.h
@@ -31,10 +31,9 @@ mirage_block_unregister_thread(void);
 /* An opened mirage-block device */
 typedef int mirage_block_handle;
 
-/* Open a mirage block device with the given URI. If buffered is true then
-   attempt to use buffering, if available. Otherwise operations are synchronous */
+/* Open a mirage block device with the given string configuration. */
 extern mirage_block_handle
-mirage_block_open(const char *uri, int buffered);
+mirage_block_open(const char *config);
 
 /* Query a mirage block device. */
 extern int


### PR DESCRIPTION
The mirage-block-unix has a revamped disk configuration interface where a `Block.Config.t` represents a desired configuration including parameters

- whether using buffered I/O or not
- whether honouring `flush` or not (possibly more options here in future)
- the path to the file

This patch simplifies the mirage block interface by using `Block.Config.of_string` rather than manually parsing a URI here. The device can then be opened with `Block.of_config`. In future if mirage-block-unix gains some extra parameters, this code won't have to be modified (hopefully)

Note this new interface is not yet in a released version, so this PR includes an extra `opam pin` in the `circle.yml`.

This is part of a workaround for [docker/for-mac#668]

Signed-off-by: David Scott <dave.scott@docker.com>