### PR TITLE
Flush any bufered data before closing the socket

### DIFF
--- a/src/pci_virtio_sock.c
+++ b/src/pci_virtio_sock.c
@@ -1502,6 +1502,11 @@ static void *pci_vtsock_tx_thread(void *vsc)
 				}
 			}
 
+			if (s->local_shutdown & VIRTIO_VSOCK_FLAG_SHUTDOWN_RX) {
+				put_sock(s);
+				continue;
+			}
+
 			if (sock_is_buffering(s)) {
 				FD_SET(s->fd, &wfd);
 				maxfd = max_fd(s->fd, maxfd);

--- a/src/pci_virtio_sock.c
+++ b/src/pci_virtio_sock.c
@@ -898,6 +898,12 @@ static void shutdown_local_sock(const char *ctx,
 	DPRINTF(("%s: setting 0x%"PRIx32" mode is now 0x%"PRIx32" (peer 0x%"PRIx32")\n",
 		 ctx, set, s->local_shutdown, s->peer_shutdown));
 
+	if (s->local_shutdown & VIRTIO_VSOCK_FLAG_SHUTDOWN_RX && s->write_buf_tail > 0) {
+		PPRINTF(("%s: discarding %d bytes from buffer\n", ctx,
+			 s->write_buf_tail - s->write_buf_head));
+		s->write_buf_tail = s->write_buf_head = 0;
+	}
+
 	if (s->local_shutdown == VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL)
 		s->rst_deadline = time(NULL) + SHUTDOWN_RST_DELAY;
 }


### PR DESCRIPTION
v7 of the vsock spec improved the semantics of the protocol on shutdown. Updating to those new semantics (in #59) has exposed a latent bug where TX data which was buffered could be lost because we did `shutdown(SHUT_WR)` on the Unix domain socket while there was still buffered data pending. Avoid this by deferring the `shutdown(SHUT_WR)` to the end of `buffer_drain`, using the difference between `sock->local_shutdown` and `sock->peer_shutdown` to know when this should be done.

There was also a crash because we would repeatedly receive `EPIPE` from the `write` in `buffer_drain` (because we were trying to write to a socket which had been closed in that direction) and hit `assert(s->local_shutdown != VIRTIO_VSOCK_FLAG_SHUTDOWN_ALL)` in `shutdown_local_sock`. The `tx_thread` should be ignoring a socket which has been `SHUT_WR`, so add a check on `local_shutdown`.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>