### PR TITLE
Remove mirage-block-unix pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,18 @@ using that to install the appropriate libraries:
     $ brew install opam
     $ opam init
     $ eval `opam config env`
-    $ opam pin add qcow-format git://github.com/mirage/ocaml-qcow#master
     $ opam install uri qcow-format
 
 Notes:
 
 - `opam config env` must be evaluated each time prior to building
   hyperkit so the build will find the ocaml environment.
-- Any previous pin of `mirage-block-unix` should be removed with the
-  commands: `opam update && opam pin remove mirage-block-unix`
+- Any previous pin of `mirage-block-unix` or `qcow-format`
+  should be removed with the commands:
+
+    $ opam update
+    $ opam pin remove mirage-block-unix
+    $ opam pin remove qcow-format
 
 ## Tracing
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Notes:
 
 - `opam config env` must be evaluated each time prior to building
   hyperkit so the build will find the ocaml environment.
-- An explicit older version of sexplib is currently required to build
-  qcow format 0.2
 - Any previous pin of `mirage-block-unix` should be removed with the
   commands: `opam update && opam pin remove mirage-block-unix`
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Notes:
   hyperkit so the build will find the ocaml environment.
 - An explicit older version of sexplib is currently required to build
   qcow format 0.2
+- Any previous pin of `mirage-block-unix` should be removed with the
+  commands: `opam update && opam pin remove mirage-block-unix`
 
 ## Tracing
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,6 @@ test:
     - brew install opam
     - opam init --yes
     - opam pin add qcow-format git://github.com/mirage/ocaml-qcow#master --yes
-    - opam pin add mirage-block-unix git://github.com/mirage/mirage-block-unix#master --yes
     - opam install --yes uri qcow-format ocamlfind
     - make clean
     - eval `opam config env` && make all

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,6 @@ test:
   override:
     - brew install opam
     - opam init --yes
-    - opam pin add qcow-format git://github.com/mirage/ocaml-qcow#master --yes
     - opam install --yes uri qcow-format ocamlfind
     - make clean
     - eval `opam config env` && make all


### PR DESCRIPTION
- remove the pin for `mirage-block-unix` (not needed any more and actually harmful as the master branch has incompatible interfaces)
- add a note to the README to explain that an existing pin to `mirage-block-unix` should be removed
- removed an out-of-date note in the README about the `sexplib` library

/cc @yomimono @ijc25 @rneugeba 