### PR TITLE
kexec: fix wrong calculation method of ramdisk_start

### DIFF
--- a/include/xhyve/firmware/kexec.h
+++ b/include/xhyve/firmware/kexec.h
@@ -29,7 +29,7 @@ struct setup_header {
 	uint8_t ext_loader_ver; /* Extended boot loader version */
 	uint8_t ext_loader_type; /* Extended boot loader ID */
 	uint32_t cmd_line_ptr; /* 32-bit pointer to the kernel command line */
-	uint32_t nitrd_addr_max; /* Highest legal initrd address */
+	uint32_t initrd_addr_max; /* Highest legal initrd address */
 	uint32_t kernel_alignment; /* Physical addr alignment required for kernel */
 	uint8_t relocatable_kernel; /* Whether kernel is relocatable or not */
 	uint8_t min_alignment; /* Minimum alignment, as a power of two */


### PR DESCRIPTION
Fix `ramdisk_start` promlem in the [kexec.c](https://github.com/docker/hyperkit/blob/master/src/firmware/kexec.c).

- Use the `initrd_addr_max` value from the kernel header if the kernel version is 2.03 or newer.
 - ref: https://github.com/zchee/linux-documentation/blob/master/x86/boot.md#initrd_addr_max
 - Use hardcoded(`0x37ffffff`) value if older.
- Compare the `initrd_max` and `memory.size`, and re-assign if `initrd_max` is larger.
- Add `ALIGNDOWN` macro for `ramdisk_start`, uses prevent to go past the address limit.
- Fix typo for `initrd_addr_max`. thanks @dlorenc

Based on [qemu/hw/i386/pc.c](https://github.com/qemu/qemu/blob/master/hw/i386/pc.c#L954-L979).

Close https://github.com/docker/hyperkit/issues/63