### PR TITLE
README.md: Attempt to direct downstream bug reports to downstream bug…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ HyperKit currently only supports Mac OS X using the [Hypervisor.framework](https
 * OS X 10.10.3 Yosemite or later
 * a 2010 or later Mac (i.e. a CPU that supports EPT)
 
+## Reporting Bugs
+
+If you are using a version of Hyperkit which is embedded into a higher level application (e.g. [Docker for Mac](https://github.com/docker/for-mac)) then please report any issues against that higher level application in the first instance. That way the relevant team can triage and determine if the issue lies in Hyperkit and assign as necessary.
+
+If you are using Hyperkit directly then please report issues against this repository.
+
 ## Usage
 
     $ com.docker.hyperkit -h


### PR DESCRIPTION
… tracker

We get a small but steady stream of Docker for Mac bug reports filled against
Hyperkit, many of which are not actually Hyperkit issues. Try and direct users
to file the bugs downstream by default so that they can be more effectively
triaged.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>