### PR TITLE
Link in libev, which is sometimes needed for Lwt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,9 @@ HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow uri >/dev/null 2>/dev/null ; 
 ifeq ($(HAVE_OCAML_QCOW),YES)
 CFLAGS += -DHAVE_OCAML=1 -DHAVE_OCAML_QCOW=1 -DHAVE_OCAML=1
 
+LIBEV_FILE=/usr/local/lib/libev.a
+LIBEV=$(shell if test -e $(LIBEV_FILE) ; then echo $(LIBEV_FILE) ; fi )
+
 # prefix vsock file names if PRI_ADDR_PREFIX
 # is defined. (not applied to aliases)
 ifneq ($(PRI_ADDR_PREFIX),)
@@ -111,6 +114,7 @@ OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query lwt.unix)/lwt.a \
 	$(shell ocamlfind query threads)/libthreadsnat.a \
 	$(shell ocamlfind query mirage-block-unix)/libmirage_block_unix_stubs.a \
+        $(LIBEV) \
 	-lasmrun -lbigarray -lunix
 
 build/hyperkit.o: CFLAGS += -I$(OCAML_WHERE)

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ The resulting binary will be in `build/com.docker.hyperkit`
 
 To enable qcow support in the block backend an OCaml [OPAM](https://opam.ocaml.org) development
 environment is required with the qcow-format module available. A
-suitable environment can be setup by installing `opam` via `brew` and
-using that to install the appropriate libraries:
+suitable environment can be setup by installing `opam` and `libev`
+via `brew` and using `opam` to install the appropriate libraries:
 
-    $ brew install opam
+    $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow-format
+    $ opam install uri qcow-format conf-libev
 
 Notes:
 

--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,9 @@ machine:
     version: "7.3"
 test:
   override:
-    - brew install opam
+    - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow-format ocamlfind
+    - opam install --yes uri qcow-format ocamlfind conf-libev
     - make clean
     - eval `opam config env` && make all
     - make test


### PR DESCRIPTION
[Lwt](https://github.com/ocsigen/lwt) [optionally depends on libev](https://github.com/ocsigen/lwt/blob/d638502667005270cb69bad282f89afa9370838e/opam#L43).  This PR updates the Makefile to statically link in `libev` if it's available.