### PR TITLE
First pass at reducing the diff between bhyve and hyperkit

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -40,6 +40,7 @@ CFLAGS_WARN := \
   \
   -Wno-dollar-in-identifier-extension \
   -Wno-gnu-statement-expression \
+  -Wno-packed \
   -Wno-padded \
   -Wno-reserved-id-macro \
   -Wno-unknown-warning-option \

--- a/config.mk
+++ b/config.mk
@@ -40,6 +40,7 @@ CFLAGS_WARN := \
   \
   -Wno-dollar-in-identifier-extension \
   -Wno-gnu-statement-expression \
+  -Wno-padded \
   -Wno-reserved-id-macro \
   -Wno-unknown-warning-option \
   -Wno-unused-macros

--- a/config.mk
+++ b/config.mk
@@ -32,14 +32,17 @@ CFLAGS_OPT := \
   -flto \
   -fstrict-aliasing
 
+# enable everything and then selectively disable some warnings
 CFLAGS_WARN := \
   -Weverything \
   -Werror \
-  -Wno-unknown-warning-option \
-  -Wno-reserved-id-macro \
+  -pedantic \
+  \
   -Wno-dollar-in-identifier-extension \
   -Wno-gnu-statement-expression \
-  -pedantic
+  -Wno-reserved-id-macro \
+  -Wno-unknown-warning-option \
+  -Wno-unused-macros
 
 CFLAGS_DIAG := \
   -fmessage-length=152 \

--- a/src/hyperkit.c
+++ b/src/hyperkit.c
@@ -121,13 +121,10 @@ static struct bhyvestats {
 	uint64_t cpu_switch_direct;
 } stats;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 static struct mt_vmm_info {
 	pthread_t mt_thr;
 	int mt_vcpu;
 } mt_vmm_info[VM_MAXCPU];
-#pragma clang diagnostic pop
 
 static uint64_t (*fw_func)(void);
 

--- a/src/include/xhyve/block_if.h
+++ b/src/include/xhyve/block_if.h
@@ -40,8 +40,6 @@
 
 #define BLOCKIF_IOV_MAX (128-2) /* not practical to be IOV_MAX */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct blockif_req {
 	struct iovec br_iov[BLOCKIF_IOV_MAX];
 	int br_iovcnt;
@@ -50,7 +48,6 @@ struct blockif_req {
 	void (*br_callback)(struct blockif_req *req, int err);
 	void *br_param;
 };
-#pragma clang diagnostic pop
 
 struct blockif_ctxt;
 struct blockif_ctxt *blockif_open(const char *optstr, const char *ident);

--- a/src/include/xhyve/firmware/kexec.h
+++ b/src/include/xhyve/firmware/kexec.h
@@ -2,8 +2,6 @@
 
 #include <stdint.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
 struct setup_header {
 	uint8_t setup_sects; /* The size of the setup in sectors */
 	uint16_t root_flags; /* If set, the root is mounted readonly */
@@ -83,7 +81,6 @@ struct zero_page {
 	uint8_t eddbuf[492];
 	uint8_t _7[276];
 } __attribute__((packed));
-#pragma clang diagnostic pop
 
 void kexec_init(char *kernel_path, char *initrd_path, char *cmdline);
 uint64_t kexec(void);

--- a/src/include/xhyve/inout.h
+++ b/src/include/xhyve/inout.h
@@ -39,8 +39,6 @@ struct vm_exit;
 typedef int (*inout_func_t)(int vcpu, int in, int port,
 	int bytes, uint32_t *eax, void *arg);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct inout_port {
 	const char *name;
 	int port;
@@ -49,7 +47,6 @@ struct inout_port {
 	inout_func_t handler;
 	void *arg;
 };
-#pragma clang diagnostic pop
 
 #define IOPORT_F_IN 0x1
 #define IOPORT_F_OUT 0x2

--- a/src/include/xhyve/mem.h
+++ b/src/include/xhyve/mem.h
@@ -34,8 +34,6 @@
 typedef int (*mem_func_t)(int vcpu, int dir, uint64_t addr, int size,
 	uint64_t *val, void *arg1, long arg2);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct mem_range {
 	const char *name;
 	int flags;
@@ -45,7 +43,6 @@ struct mem_range {
 	uint64_t base;
 	uint64_t size;
 };
-#pragma clang diagnostic pop
 
 #define MEM_F_READ 0x1
 #define MEM_F_WRITE 0x2

--- a/src/include/xhyve/pci_emul.h
+++ b/src/include/xhyve/pci_emul.h
@@ -69,14 +69,11 @@ enum pcibar_type {
 	PCIBAR_MEMHI64
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct pcibar {
 	enum pcibar_type type; /* io or memory */
 	uint64_t size;
 	uint64_t addr;
 };
-#pragma clang diagnostic pop
 
 #define PI_NAMESZ 40
 
@@ -100,8 +97,6 @@ enum lintr_stat {
 	PENDING
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct pci_devinst {
 	struct pci_devemu *pi_d;
 	uint8_t pi_bus, pi_slot, pi_func;
@@ -142,7 +137,6 @@ struct pci_devinst {
 	u_char pi_cfgdata[PCI_REGMAX + 1];
 	struct pcibar pi_bar[PCI_BARMAX + 1];
 };
-#pragma clang diagnostic pop
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpacked"

--- a/src/include/xhyve/pci_emul.h
+++ b/src/include/xhyve/pci_emul.h
@@ -138,8 +138,6 @@ struct pci_devinst {
 	struct pcibar pi_bar[PCI_BARMAX + 1];
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
 struct msicap {
 	uint8_t capid;
 	uint8_t nextptr;
@@ -190,7 +188,6 @@ struct pciecap {
 	uint16_t slot_control2;
 	uint16_t slot_status2;
 } __packed;
-#pragma clang diagnostic pop
 
 typedef void (*pci_lintr_cb)(int b, int s, int pin, int pirq_pin,
 	int ioapic_irq, void *arg);

--- a/src/include/xhyve/pci_lpc.h
+++ b/src/include/xhyve/pci_lpc.h
@@ -48,14 +48,11 @@ enum lpc_sysres_type {
 	LPC_SYSRES_MEM
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct lpc_sysres {
 	enum lpc_sysres_type type;
 	uint32_t base;
 	uint32_t length;
 };
-#pragma clang diagnostic pop
 
 #define	LPC_SYSRES(type, base, length) \
 	static struct lpc_sysres __CONCAT(__lpc_sysres, base) = {\

--- a/src/include/xhyve/support/ata.h
+++ b/src/include/xhyve/support/ata.h
@@ -30,9 +30,6 @@
 
 #include <xhyve/support/misc.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
-
 /* ATA/ATAPI device parameters */
 struct ata_params {
 /*000*/ u_int16_t       config;         /* configuration info */
@@ -638,5 +635,3 @@ struct ata_ioc_raid_status {
 #define IOCATARAIDSTATUS        _IOWR('a', 202, struct ata_ioc_raid_status)
 #define IOCATARAIDADDSPARE      _IOW('a', 203, struct ata_ioc_raid_config)
 #define IOCATARAIDREBUILD       _IOW('a', 204, int)
-
-#pragma clang diagnostic pop

--- a/src/include/xhyve/support/ata.h
+++ b/src/include/xhyve/support/ata.h
@@ -31,7 +31,6 @@
 #include <xhyve/support/misc.h>
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 #pragma clang diagnostic ignored "-Wpacked"
 
 /* ATA/ATAPI device parameters */

--- a/src/include/xhyve/support/md5.h
+++ b/src/include/xhyve/support/md5.h
@@ -33,15 +33,12 @@ documentation and/or software.
 #define MD5_DIGEST_LENGTH 16
 #define MD5_DIGEST_STRING_LENGTH (MD5_DIGEST_LENGTH * 2 + 1)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 /* MD5 context. */
 typedef struct MD5Context {
   u_int32_t state[4];	/* state (ABCD) */
   u_int32_t count[2];	/* number of bits, modulo 2^64 (lsb first) */
   unsigned char buffer[64];	/* input buffer */
 } MD5_CTX;
-#pragma clang diagnostic pop
 
 void MD5Init(MD5_CTX *);
 void MD5Update(MD5_CTX *, const void *, unsigned int);

--- a/src/include/xhyve/support/mptable.h
+++ b/src/include/xhyve/support/mptable.h
@@ -43,9 +43,6 @@ enum busTypes {
     UNKNOWN_BUSTYPE = 0xff
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
-
 /* MP Floating Pointer Structure */
 typedef struct MPFPS {
 	uint8_t	signature[4];
@@ -190,5 +187,3 @@ typedef struct CBASMENTRY {
 
 #define	CBASMENTRY_RANGE_ISA_IO		0
 #define	CBASMENTRY_RANGE_VGA_IO		1
-
-#pragma clang diagnostic pop

--- a/src/include/xhyve/support/segments.h
+++ b/src/include/xhyve/support/segments.h
@@ -59,8 +59,6 @@
  * For long-mode apps, %cs only has the conforming bit in sd_type, the sd_dpl,
  * sd_p, sd_l and sd_def32 which must be zero).  %ds only has sd_p.
  */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
 struct segment_descriptor {
 	unsigned sd_lolimit:16;		/* segment extent (lsb) */
 	unsigned sd_lobase:24;		/* segment base address (lsb) */
@@ -73,7 +71,6 @@ struct segment_descriptor {
 	unsigned sd_gran:1;		/* limit granularity (byte/page units)*/
 	unsigned sd_hibase:8;		/* segment base address  (msb) */
 } __packed;
-#pragma clang diagnostic pop
 
 struct user_segment_descriptor {
 	uint64_t sd_lolimit:16; /* segment extent (lsb) */

--- a/src/include/xhyve/support/tree.h
+++ b/src/include/xhyve/support/tree.h
@@ -29,9 +29,6 @@
 
 #pragma once
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
-
 /*
  * This file defines data structures for different types of trees:
  * splay trees and red-black trees.
@@ -747,5 +744,3 @@ name##_RB_MINMAX(struct name *head, int val)				\
 	for ((x) = RB_MAX(name, head);					\
 	     (x) != NULL;						\
 	     (x) = name##_RB_PREV(x))
-
-#pragma clang diagnostic pop

--- a/src/include/xhyve/support/uuid.h
+++ b/src/include/xhyve/support/uuid.h
@@ -35,8 +35,6 @@
 
 #define	_UUID_NODE_LEN 6
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct uuid {
 	uint32_t time_low;
 	uint16_t time_mid;
@@ -45,7 +43,6 @@ struct uuid {
 	uint8_t clock_seq_low;
 	uint8_t node[_UUID_NODE_LEN];
 };
-#pragma clang diagnostic pop
 
 typedef struct uuid uuid_internal_t;
 

--- a/src/include/xhyve/virtio.h
+++ b/src/include/xhyve/virtio.h
@@ -325,9 +325,6 @@ struct vqueue_info;
 #define	VIRTIO_EVENT_IDX	0x02	/* use the event-index values */
 #define	VIRTIO_BROKED		0x08	/* ??? */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
-
 struct virtio_softc {
 	struct virtio_consts *vs_vc; /* constants (see below) */
 	int vs_flags; /* VIRTIO_* flags from above */
@@ -419,8 +416,6 @@ struct vqueue_info {
 	/* the "used" ring */
 	volatile struct vring_used *vq_used;
 };
-
-#pragma clang diagnostic pop
 
 /* as noted above, these are sort of backwards, name-wise */
 #define VQ_AVAIL_EVENT_IDX(vq) \

--- a/src/include/xhyve/virtio.h
+++ b/src/include/xhyve/virtio.h
@@ -127,9 +127,6 @@
 #define VRING_DESC_F_WRITE	(1 << 1)
 #define VRING_DESC_F_INDIRECT	(1 << 2)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
-
 struct virtio_desc { /* AKA vring_desc */
 	uint64_t vd_addr; /* guest physical address */
 	uint32_t vd_len; /* length of scatter/gather seg */
@@ -158,8 +155,6 @@ struct vring_used {
 	struct virtio_used vu_ring[]; /* size N */
 /*	uint16_t vu_avail_event; -- after N ring entries */
 } __packed;
-
-#pragma clang diagnostic pop
 
 /*
  * The address of any given virtual queue is determined by a single

--- a/src/include/xhyve/vmm/intel/vmx.h
+++ b/src/include/xhyve/vmm/intel/vmx.h
@@ -40,14 +40,11 @@ struct vmxcap {
 	uint32_t proc_ctls2;
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vmxstate {
 	uint64_t nextrip;	/* next instruction to be executed by guest */
 	int	lastcpu;	/* host cpu that this 'vcpu' last ran on */
 	uint16_t vpid;
 };
-#pragma clang diagnostic pop
 
 struct apic_page {
 	uint32_t reg[XHYVE_PAGE_SIZE / 4];

--- a/src/include/xhyve/vmm/io/vlapic_priv.h
+++ b/src/include/xhyve/vmm/io/vlapic_priv.h
@@ -149,8 +149,6 @@ struct vlapic_ops {
 	void (*enable_x2apic_mode)(struct vlapic *vlapic);
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vlapic {
 	struct vm *vm;
 	int vcpuid;
@@ -183,7 +181,6 @@ struct vlapic {
 	uint32_t svr_last;
 	uint32_t lvt_last[VLAPIC_MAXLVT_INDEX + 1];
 };
-#pragma clang diagnostic pop
 
 void vlapic_init(struct vlapic *vlapic);
 void vlapic_cleanup(struct vlapic *vlapic);

--- a/src/include/xhyve/vmm/vmm.h
+++ b/src/include/xhyve/vmm/vmm.h
@@ -35,8 +35,6 @@
 #include <xhyve/support/segments.h>
 #include <xhyve/vmm/vmm_common.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 
 #define	VM_INTINFO_VECTOR(info)	((info) & 0xff)
 #define	VM_INTINFO_DEL_ERRCODE	0x800
@@ -312,5 +310,3 @@ vm_inject_ss(void *vm, int vcpuid, int errcode)
 void vm_inject_pf(void *vm, int vcpuid, int error_code, uint64_t cr2);
 
 int vm_restart_instruction(void *vm, int vcpuid);
-
-#pragma clang diagnostic pop

--- a/src/include/xhyve/vmm/vmm_common.h
+++ b/src/include/xhyve/vmm/vmm_common.h
@@ -30,9 +30,6 @@
 
 #include <stdint.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
-
 #define	VM_MAXCPU 16 /* maximum virtual cpus */
 
 enum vm_suspend_how {
@@ -318,5 +315,3 @@ int vie_calculate_gla(enum vm_cpu_mode cpu_mode, enum vm_reg_name seg,
 
 int vie_alignment_check(int cpl, int operand_size, uint64_t cr0,
 	uint64_t rflags, uint64_t gla);
-
-#pragma clang diagnostic pop

--- a/src/include/xhyve/vmm/vmm_host.h
+++ b/src/include/xhyve/vmm/vmm_host.h
@@ -30,14 +30,11 @@
 
 #include <stdint.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct xsave_limits {
 	int		xsave_enabled;
 	uint64_t	xcr0_allowed;
 	uint32_t	xsave_max_size;
 };
-#pragma clang diagnostic pop
 
 void vmm_host_state_init(void);
 

--- a/src/include/xhyve/vmm/vmm_stat.h
+++ b/src/include/xhyve/vmm/vmm_stat.h
@@ -48,8 +48,6 @@ struct vmm_stat_type;
 typedef void (*vmm_stat_func_t)(struct vm *vm, int vcpu,
     struct vmm_stat_type *stat);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vmm_stat_type {
 	int	index;			/* position in the stats buffer */
 	int	nelems;			/* standalone or array */
@@ -57,7 +55,6 @@ struct vmm_stat_type {
 	vmm_stat_func_t func;
 	enum vmm_stat_scope scope;
 };
-#pragma clang diagnostic pop
 
 void	vmm_stat_register(void *arg);
 

--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -78,8 +78,6 @@ enum blockstat {
 	BST_DONE
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct blockif_elem {
 	TAILQ_ENTRY(blockif_elem) be_link;
 	struct blockif_req  *be_req;
@@ -127,7 +125,6 @@ struct blockif_sig_elem {
 
 static struct blockif_sig_elem *blockif_bse_head;
 
-#pragma clang diagnostic pop
 
 static ssize_t
 preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset)

--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -51,7 +51,8 @@
 
 #include "mirage_block_c.h"
 
-#define BLOCKIF_SIG 0xb109b109
+#define BLOCKIF_SIG	0xb109b109
+
 /* xhyve: FIXME
  *
  * // #define BLOCKIF_NUMTHR 8
@@ -59,9 +60,8 @@
  * OS X does not support preadv/pwritev, we need to serialize reads and writes
  * for the time being until we find a better solution.
  */
-#define BLOCKIF_NUMTHR 1
-
-#define BLOCKIF_MAXREQ (128 + BLOCKIF_NUMTHR)
+#define BLOCKIF_NUMTHR	1
+#define BLOCKIF_MAXREQ	(128 + BLOCKIF_NUMTHR)
 
 enum blockop {
 	BOP_READ,
@@ -82,33 +82,33 @@ enum blockstat {
 #pragma clang diagnostic ignored "-Wpadded"
 struct blockif_elem {
 	TAILQ_ENTRY(blockif_elem) be_link;
-	struct blockif_req *be_req;
-	enum blockop be_op;
-	enum blockstat be_status;
-	pthread_t be_tid;
-	off_t be_block;
+	struct blockif_req  *be_req;
+	enum blockop	     be_op;
+	enum blockstat	     be_status;
+	pthread_t            be_tid;
+	off_t		     be_block;
 };
 
 struct blockif_ctxt {
-	int bc_magic;
-	char ident[16];
-	/* Only one of fd and bc_mbh may be >= 0 */
-	int bc_fd;
+	int			bc_magic;
+	char			ident[16];
+	int			bc_fd;
 #ifdef HAVE_OCAML_QCOW
-	mirage_block_handle bc_mbh;
+	mirage_block_handle	bc_mbh;
 #endif
-	int bc_ischr;
-	int bc_isgeom;
-	int bc_candelete;
-	int bc_rdonly;
-	off_t bc_size;
-	int bc_sectsz;
-	int bc_psectsz;
-	int bc_psectoff;
-	int bc_closing;
-	pthread_t bc_btid[BLOCKIF_NUMTHR];
-	pthread_mutex_t bc_mtx;
-	pthread_cond_t bc_cond;
+	int			bc_ischr;
+	int			bc_isgeom;
+	int			bc_candelete;
+	int			bc_rdonly;
+	off_t			bc_size;
+	int			bc_sectsz;
+	int			bc_psectsz;
+	int			bc_psectoff;
+	int			bc_closing;
+	pthread_t		bc_btid[BLOCKIF_NUMTHR];
+        pthread_mutex_t		bc_mtx;
+        pthread_cond_t		bc_cond;
+
 	/* Request elements and free/pending/busy queues */
 	TAILQ_HEAD(, blockif_elem) bc_freeq;
 	TAILQ_HEAD(, blockif_elem) bc_pendq;
@@ -119,10 +119,10 @@ struct blockif_ctxt {
 static pthread_once_t blockif_once = PTHREAD_ONCE_INIT;
 
 struct blockif_sig_elem {
-	pthread_mutex_t bse_mtx;
-	pthread_cond_t bse_cond;
-	int bse_pending;
-	struct blockif_sig_elem *bse_next;
+	pthread_mutex_t			bse_mtx;
+	pthread_cond_t			bse_cond;
+	int				bse_pending;
+	struct blockif_sig_elem		*bse_next;
 };
 
 static struct blockif_sig_elem *blockif_bse_head;
@@ -136,8 +136,9 @@ preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset)
 
 	res = lseek(fd, offset, SEEK_SET);
 	assert(res == offset);
-	return readv(fd, iov, iovcnt);
+	return (readv(fd, iov, iovcnt));
 }
+
 
 static ssize_t
 pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset)
@@ -146,8 +147,9 @@ pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset)
 
 	res = lseek(fd, offset, SEEK_SET);
 	assert(res == offset);
-	return writev(fd, iov, iovcnt);
+	return (writev(fd, iov, iovcnt));
 }
+
 
 static inline size_t iovec_len(const struct iovec *iov, int iovcnt)
 {
@@ -156,11 +158,14 @@ static inline size_t iovec_len(const struct iovec *iov, int iovcnt)
 
 	for (i = 0; i < iovcnt; i++)
 		len += iov[i].iov_len;
-	return len;
+
+	return (len);
 }
 
+
 static ssize_t
-block_preadv(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt, off_t offset)
+block_preadv(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt,
+	     off_t offset)
 {
 	ssize_t ret;
 
@@ -169,6 +174,7 @@ block_preadv(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt, off_t
 
 	if (bc->bc_fd >= 0)
 		ret = preadv(bc->bc_fd, iov, iovcnt, offset);
+
 #ifdef HAVE_OCAML_QCOW
 	else if (bc->bc_mbh >= 0)
 		ret = mirage_block_preadv(bc->bc_mbh, iov, iovcnt, offset);
@@ -177,11 +183,13 @@ block_preadv(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt, off_t
 		abort();
 
 	HYPERKIT_BLOCK_PREADV_DONE(offset, ret);
-	return ret;
+	return (ret);
 }
 
+
 static ssize_t
-block_pwritev(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt, off_t offset)
+block_pwritev(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt,
+	      off_t offset)
 {
 	ssize_t ret;
 
@@ -190,6 +198,7 @@ block_pwritev(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt, off_
 
 	if (bc->bc_fd >= 0)
 		ret = pwritev(bc->bc_fd, iov, iovcnt, offset);
+
 #ifdef HAVE_OCAML_QCOW
 	else if (bc->bc_mbh >= 0)
 		ret = mirage_block_pwritev(bc->bc_mbh, iov, iovcnt, offset);
@@ -198,37 +207,44 @@ block_pwritev(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt, off_
 		abort();
 
 	HYPERKIT_BLOCK_PWRITEV_DONE(offset, ret);
-	return ret;
+	return (ret);
 }
+
 
 static int
 block_flush(struct blockif_ctxt *bc)
 {
 	if (bc->bc_fd >= 0) {
 		if (bc->bc_ischr) {
-                        if (ioctl(bc->bc_fd, DKIOCSYNCHRONIZECACHE))
-                                return errno;
-                } else if (fsync(bc->bc_fd))
-                        return errno;
-		return 0;
+			if (ioctl(bc->bc_fd, DKIOCSYNCHRONIZECACHE))
+				return (errno);
+		} else if (fsync(bc->bc_fd))
+			return (errno);
+		return (0);
+
 #ifdef HAVE_OCAML_QCOW
 	} else if (bc->bc_mbh >= 0) {
 		if (mirage_block_flush(bc->bc_mbh))
-			 return errno;
-		return 0;
+			return (errno);
+		return (0);
 #endif
 	} else
 		abort();
 }
+
+
 static int
 block_close(struct blockif_ctxt *bc)
 {
-	if (bc->bc_fd >= 0) return close(bc->bc_fd);
+	if (bc->bc_fd >= 0)
+		return (close(bc->bc_fd));
 #ifdef HAVE_OCAML_QCOW
-	if (bc->bc_mbh >= 0) return mirage_block_close(bc->bc_mbh);
+	if (bc->bc_mbh >= 0)
+		return (mirage_block_close(bc->bc_mbh));
 #endif
 	abort();
 }
+
 
 static int
 blockif_enqueue(struct blockif_ctxt *bc, struct blockif_req *breq,
@@ -329,7 +345,7 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 	case BOP_READ:
 		if (buf == NULL) {
 			if ((len = block_preadv(bc, br->br_iov, br->br_iovcnt,
-				   br->br_offset)) < 0)
+			           br->br_offset)) < 0)
 				err = errno;
 			else
 				br->br_resid -= len;
@@ -341,19 +357,19 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 			len = MIN(br->br_resid, MAXPHYS);
 			struct iovec iov;
 			iov.iov_base = buf;
-			iov.iov_len = (size_t) len;
-			if (block_preadv(bc, &iov, 1, br->br_offset + off) < 0)
-			{
+			iov.iov_len = (size_t)len;
+			if (block_preadv(bc, &iov, 1,
+					 br->br_offset + off) < 0) {
 				err = errno;
 				break;
 			}
 			boff = 0;
 			do {
-				clen = MIN((len - boff),
-					(((ssize_t) br->br_iov[i].iov_len) - voff));
-				memcpy(((void *) (((uintptr_t) br->br_iov[i].iov_base) +
-					((size_t) voff))), buf + boff, clen);
-				if (clen < (((ssize_t) br->br_iov[i].iov_len) - voff))
+				clen = MIN(len - boff,
+				    (ssize_t)br->br_iov[i].iov_len - voff);
+				memcpy((char *)br->br_iov[i].iov_base + voff,
+				    buf + boff, clen);
+				if (clen < (ssize_t)br->br_iov[i].iov_len - voff)
 					voff += clen;
 				else {
 					i++;
@@ -372,7 +388,7 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 		}
 		if (buf == NULL) {
 			if ((len = block_pwritev(bc, br->br_iov, br->br_iovcnt,
-				    br->br_offset)) < 0)
+			           br->br_offset)) < 0)
 				err = errno;
 			else
 				br->br_resid -= len;
@@ -384,12 +400,13 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 			len = MIN(br->br_resid, MAXPHYS);
 			boff = 0;
 			do {
-				clen = MIN((len - boff),
-					(((ssize_t) br->br_iov[i].iov_len) - voff));
-				memcpy((buf + boff),
-					((void *) (((uintptr_t) br->br_iov[i].iov_base) +
-						((size_t) voff))), clen);
-				if (clen < (((ssize_t) br->br_iov[i].iov_len) - voff))
+				clen = MIN(len - boff,
+				    (ssize_t)br->br_iov[i].iov_len - voff);
+				memcpy(buf + boff,
+				    (char *)br->br_iov[i].iov_base + voff,
+				    clen);
+				if (clen <
+				    (ssize_t)br->br_iov[i].iov_len - voff)
 					voff += clen;
 				else {
 					i++;
@@ -399,7 +416,7 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 			} while (boff < len);
 			struct iovec iov;
 			iov.iov_base = buf;
-			iov.iov_len = (size_t) len;
+			iov.iov_len = (size_t)len;
 			if (block_pwritev(bc, &iov, 1, br->br_offset +
 			    off) < 0) {
 				err = errno;
@@ -413,21 +430,23 @@ blockif_proc(struct blockif_ctxt *bc, struct blockif_elem *be, uint8_t *buf)
 		err = block_flush(bc);
 		break;
 	case BOP_DELETE:
-		if (!bc->bc_candelete) {
+#ifdef __FreeBSD__
+		if (!bc->bc_candelete)
 			err = EOPNOTSUPP;
-		// } else if (bc->bc_rdonly) {
-		// 	err = EROFS;
-		// } else if (bc->bc_ischr) {
-		// 	arg[0] = br->br_offset;
-		// 	arg[1] = br->br_resid;
-		// 	if (ioctl(bc->bc_fd, DIOCGDELETE, arg)) {
-		// 		err = errno;
-		// 	} else {
-		// 		br->br_resid = 0;
-		// 	}
-		} else {
+		else if (bc->bc_rdonly)
+			err = EROFS;
+		else if (bc->bc_ischr) {
+			arg[0] = br->br_offset;
+			arg[1] = br->br_resid;
+			if (ioctl(bc->bc_fd, DIOCGDELETE, arg))
+				err = errno;
+			else
+				br->br_resid = 0;
+		} else
 			err = EOPNOTSUPP;
-		}
+#else
+		err = EOPNOTSUPP;
+#endif
 		break;
 	}
 
@@ -480,7 +499,7 @@ blockif_thr(void *arg)
 
 static void
 blockif_sigcont_handler(UNUSED int signal, UNUSED enum ev_type type,
-	UNUSED void *arg)
+			UNUSED void *arg)
 {
 	struct blockif_sig_elem *bse;
 
@@ -535,6 +554,7 @@ blockif_open(const char *optstr, const char *ident)
 	ro = 0;
 
 	pssopt = 0;
+
 	/*
 	 * The first element in the optstring is always a pathname.
 	 * Optional elements follow
@@ -591,7 +611,7 @@ blockif_open(const char *optstr, const char *ident)
 #endif
 	} else {
 		fd = open(nopt, (ro ? O_RDONLY : O_RDWR) | extra);
-		if (fd < 0 && !ro) {
+		if ((fd < 0) && !ro) {
 			/* Attempt a r/w fail with a r/o open */
 			fd = open(nopt, O_RDONLY | extra);
 			ro = 1;
@@ -619,24 +639,26 @@ blockif_open(const char *optstr, const char *ident)
 	psectsz = psectoff = 0;
 	candelete = geom = 0;
 	if (S_ISCHR(sbuf.st_mode)) {
+#ifdef __FreeBSD__
+		if (ioctl(fd, DIOCGMEDIASIZE, &size) < 0 ||
+		    ioctl(fd, DIOCGSECTORSIZE, &sectsz)) {
+			perror("Could not fetch dev blk/sector size");
+			goto err;
+		}
+		assert(size != 0);
+		assert(sectsz != 0);
+		if (ioctl(fd, DIOCGSTRIPESIZE, &psectsz) == 0 && psectsz > 0)
+			ioctl(fd, DIOCGSTRIPEOFFSET, &psectoff);
+		strlcpy(arg.name, "GEOM::candelete", sizeof(arg.name));
+		arg.len = sizeof(arg.value.i);
+		if (ioctl(fd, DIOCGATTR, &arg) == 0)
+			candelete = arg.value.i;
+		if (ioctl(fd, DIOCGPROVIDERNAME, name) == 0)
+			geom = 1;
+#else
 		perror("xhyve: raw device support unimplemented");
 		goto err;
-		// if (ioctl(fd, DIOCGMEDIASIZE, &size) < 0 ||
-		// 	ioctl(fd, DIOCGSECTORSIZE, &sectsz))
-		// {
-		// 	perror("Could not fetch dev blk/sector size");
-		// 	goto err;
-		// }
-		// assert(size != 0);
-		// assert(sectsz != 0);
-		// if (ioctl(fd, DIOCGSTRIPESIZE, &psectsz) == 0 && psectsz > 0)
-		// 	ioctl(fd, DIOCGSTRIPEOFFSET, &psectoff);
-		// strlcpy(arg.name, "GEOM::candelete", sizeof(arg.name));
-		// arg.len = sizeof(arg.value.i);
-		// if (ioctl(fd, DIOCGATTR, &arg) == 0)
-		// 	candelete = arg.value.i;
-		// if (ioctl(fd, DIOCGPROVIDERNAME, name) == 0)
-		// 	geom = 1;
+#endif
 	} else
 		psectsz = sbuf.st_blksize;
 
@@ -648,21 +670,23 @@ blockif_open(const char *optstr, const char *ident)
 			goto err;
 		}
 
-		// /*
-		//  * Some backend drivers (e.g. cd0, ada0) require that the I/O
-		//  * size be a multiple of the device's sector size.
-		//  *
-		//  * Validate that the emulated sector size complies with this
-		//  * requirement.
-		//  */
-		// if (S_ISCHR(sbuf.st_mode)) {
-		// 	if (ssopt < sectsz || (ssopt % sectsz) != 0) {
-		// 		fprintf(stderr, "Sector size %d incompatible "
-		// 		    "with underlying device sector size %d\n",
-		// 		    ssopt, sectsz);
-		// 		goto err;
-		// 	}
-		// }
+#ifdef __FreeBSD__
+		/*
+		 * Some backend drivers (e.g. cd0, ada0) require that the I/O
+		 * size be a multiple of the device's sector size.
+		 *
+		 * Validate that the emulated sector size complies with this
+		 * requirement.
+		 */
+		if (S_ISCHR(sbuf.st_mode)) {
+			if (ssopt < sectsz || (ssopt % sectsz) != 0) {
+				fprintf(stderr, "Sector size %d incompatible "
+				    "with underlying device sector size %d\n",
+				    ssopt, sectsz);
+				goto err;
+			}
+		}
+#endif
 
 		sectsz = ssopt;
 		psectsz = pssopt;
@@ -675,7 +699,7 @@ blockif_open(const char *optstr, const char *ident)
 		goto err;
 	}
 
-	bc->bc_magic = (int) BLOCKIF_SIG;
+	bc->bc_magic = (int)BLOCKIF_SIG;
 	snprintf(bc->ident, sizeof(bc->ident), "blk:%s", ident);
 	bc->bc_fd = fd;
 #ifdef HAVE_OCAML_QCOW
@@ -687,8 +711,8 @@ blockif_open(const char *optstr, const char *ident)
 	bc->bc_rdonly = ro;
 	bc->bc_size = size;
 	bc->bc_sectsz = sectsz;
-	bc->bc_psectsz = (int) psectsz;
-	bc->bc_psectoff = (int) psectoff;
+	bc->bc_psectsz = (int)psectsz;
+	bc->bc_psectoff = (int)psectoff;
 	pthread_mutex_init(&bc->bc_mtx, NULL);
 	pthread_cond_init(&bc->bc_cond, NULL);
 	TAILQ_INIT(&bc->bc_freeq);
@@ -747,28 +771,32 @@ blockif_request(struct blockif_ctxt *bc, struct blockif_req *breq,
 int
 blockif_read(struct blockif_ctxt *bc, struct blockif_req *breq)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (blockif_request(bc, breq, BOP_READ));
 }
 
 int
 blockif_write(struct blockif_ctxt *bc, struct blockif_req *breq)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (blockif_request(bc, breq, BOP_WRITE));
 }
 
 int
 blockif_flush(struct blockif_ctxt *bc, struct blockif_req *breq)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (blockif_request(bc, breq, BOP_FLUSH));
 }
 
 int
 blockif_delete(struct blockif_ctxt *bc, struct blockif_req *breq)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (blockif_request(bc, breq, BOP_DELETE));
 }
 
@@ -777,7 +805,7 @@ blockif_cancel(struct blockif_ctxt *bc, struct blockif_req *breq)
 {
 	struct blockif_elem *be;
 
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 
 	pthread_mutex_lock(&bc->bc_mtx);
 	/*
@@ -852,11 +880,9 @@ int
 blockif_close(struct blockif_ctxt *bc)
 {
 	void *jval;
-	int err, i;
+	int i;
 
-	err = 0;
-
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 
 	/*
 	 * Stop the block i/o thread
@@ -892,7 +918,7 @@ blockif_chs(struct blockif_ctxt *bc, uint16_t *c, uint8_t *h, uint8_t *s)
 	uint16_t secpt;		/* sectors per track */
 	uint8_t heads;
 
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 
 	sectors = bc->bc_size / bc->bc_sectsz;
 
@@ -907,7 +933,7 @@ blockif_chs(struct blockif_ctxt *bc, uint16_t *c, uint8_t *h, uint8_t *s)
 	} else {
 		secpt = 17;
 		hcyl = sectors / secpt;
-		heads = (uint8_t) ((hcyl + 1023) / 1024);
+		heads = (uint8_t)((hcyl + 1023) / 1024);
 
 		if (heads < 4)
 			heads = 4;
@@ -924,9 +950,9 @@ blockif_chs(struct blockif_ctxt *bc, uint16_t *c, uint8_t *h, uint8_t *s)
 		}
 	}
 
-	*c = (uint16_t) (hcyl / heads);
+	*c = (uint16_t)(hcyl / heads);
 	*h = heads;
-	*s = (uint8_t) secpt;
+	*s = (uint8_t)secpt;
 }
 
 /*
@@ -935,21 +961,24 @@ blockif_chs(struct blockif_ctxt *bc, uint16_t *c, uint8_t *h, uint8_t *s)
 off_t
 blockif_size(struct blockif_ctxt *bc)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (bc->bc_size);
 }
 
 int
 blockif_sectsz(struct blockif_ctxt *bc)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (bc->bc_sectsz);
 }
 
 void
 blockif_psectsz(struct blockif_ctxt *bc, int *size, int *off)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	*size = bc->bc_psectsz;
 	*off = bc->bc_psectoff;
 }
@@ -957,20 +986,23 @@ blockif_psectsz(struct blockif_ctxt *bc, int *size, int *off)
 int
 blockif_queuesz(struct blockif_ctxt *bc)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (BLOCKIF_MAXREQ - 1);
 }
 
 int
 blockif_is_ro(struct blockif_ctxt *bc)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (bc->bc_rdonly);
 }
 
 int
 blockif_candelete(struct blockif_ctxt *bc)
 {
-	assert(bc->bc_magic == ((int) BLOCKIF_SIG));
+
+	assert(bc->bc_magic == (int)BLOCKIF_SIG);
 	return (bc->bc_candelete);
 }

--- a/src/lib/firmware/fbsd.c
+++ b/src/lib/firmware/fbsd.c
@@ -427,8 +427,6 @@ cb_poll(UNUSED void *arg)
  * Host filesystem i/o callbacks
  */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct cb_file {
 	int cf_isdir;
 	size_t cf_size;
@@ -438,7 +436,6 @@ struct cb_file {
 		DIR *dir;
 	} cf_u;
 };
-#pragma clang diagnostic pop
 
 static int
 cb_open(UNUSED void *arg, const char *filename, void **hp)

--- a/src/lib/inout.c
+++ b/src/lib/inout.c
@@ -50,16 +50,16 @@ SET_DECLARE(inout_port_set, struct inout_port);
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 static struct {
-	const char *name;
-	int flags;
-	inout_func_t handler;
-	void *arg;
+	const char	*name;
+	int		flags;
+	inout_func_t	handler;
+	void		*arg;
 } inout_handlers[MAX_IOPORTS];
 #pragma clang diagnostic pop
 
 static int
 default_inout(UNUSED int vcpu, int in, UNUSED int port, int bytes,
-	uint32_t *eax, UNUSED void *arg)
+	      uint32_t *eax, UNUSED void *arg)
 {
 	if (in) {
 		switch (bytes) {
@@ -89,7 +89,7 @@ register_default_iohandler(int start, int size)
 	iop.name = "default";
 	iop.port = start;
 	iop.size = size;
-	iop.flags = (int) (IOPORT_F_INOUT | IOPORT_F_DEFAULT);
+	iop.flags = (int)(IOPORT_F_INOUT | IOPORT_F_DEFAULT);
 	iop.handler = default_inout;
 
 	register_inout(&iop);
@@ -97,7 +97,7 @@ register_default_iohandler(int start, int size)
 
 static int
 update_register(int vcpuid, enum vm_reg_name reg,
-	uint64_t val, int size)
+		uint64_t val, int size)
 {
 	int error;
 	uint64_t origval;
@@ -186,7 +186,7 @@ emulate_inout(int vcpu, struct vm_exit *vmexit, int strict)
 			}
 
 			error = xh_vm_copy_setup(vcpu, &vis->paging, gla,
-			    ((size_t) bytes), prot, iov, nitems(iov), &fault);
+			    (size_t)bytes, prot, iov, nitems(iov), &fault);
 			if (error) {
 				retval = -1;  /* Unrecoverable error */
 				break;
@@ -203,20 +203,20 @@ emulate_inout(int vcpu, struct vm_exit *vmexit, int strict)
 
 			val = 0;
 			if (!in)
-				xh_vm_copyin(iov, &val, ((size_t) bytes));
+				xh_vm_copyin(iov, &val, (size_t)bytes);
 
 			retval = handler(vcpu, in, port, bytes, &val, arg);
 			if (retval != 0)
 				break;
 
 			if (in)
-				xh_vm_copyout(&val, iov, ((size_t) bytes));
+				xh_vm_copyout(&val, iov, (size_t)bytes);
 
 			/* Update index */
 			if (vis->rflags & PSL_D)
-				index -= ((uint64_t) bytes);
+				index -= (uint64_t)bytes;
 			else
-				index += ((uint64_t) bytes);
+				index += (uint64_t)bytes;
 
 			count--;
 			iterations--;
@@ -288,9 +288,9 @@ register_inout(struct inout_port *iop)
 	 * Verify that the new registration is not overwriting an already
 	 * allocated i/o range.
 	 */
-	if ((((unsigned) iop->flags) & IOPORT_F_DEFAULT) == 0) {
+	if (((unsigned)iop->flags & IOPORT_F_DEFAULT) == 0) {
 		for (i = iop->port; i < iop->port + iop->size; i++) {
-			if ((((unsigned) inout_handlers[i].flags) & IOPORT_F_DEFAULT) == 0)
+			if (((unsigned)inout_handlers[i].flags & IOPORT_F_DEFAULT) == 0)
 				return (-1);
 		}
 	}

--- a/src/lib/inout.c
+++ b/src/lib/inout.c
@@ -47,15 +47,12 @@ SET_DECLARE(inout_port_set, struct inout_port);
 #define	VERIFY_IOPORT(port, size) \
 	assert((port) >= 0 && (size) > 0 && ((port) + (size)) <= MAX_IOPORTS)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 static struct {
 	const char	*name;
 	int		flags;
 	inout_func_t	handler;
 	void		*arg;
 } inout_handlers[MAX_IOPORTS];
-#pragma clang diagnostic pop
 
 static int
 default_inout(UNUSED int vcpu, int in, UNUSED int port, int bytes,

--- a/src/lib/mem.c
+++ b/src/lib/mem.c
@@ -43,15 +43,12 @@
 #include <xhyve/vmm/vmm_api.h>
 #include <xhyve/mem.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct mmio_rb_range {
 	RB_ENTRY(mmio_rb_range) mr_link; /* RB tree links */
 	struct mem_range mr_param;
 	uint64_t mr_base;
 	uint64_t mr_end;
 };
-#pragma clang diagnostic pop
 
 struct mmio_rb_tree;
 RB_PROTOTYPE(mmio_rb_tree, mmio_rb_range, mr_link, mmio_rb_range_compare);

--- a/src/lib/mevent.c
+++ b/src/lib/mevent.c
@@ -58,8 +58,6 @@ static int mevent_timid = 43;
 static int mevent_pipefd[2];
 static pthread_mutex_t mevent_lmutex = PTHREAD_MUTEX_INITIALIZER;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct mevent {
 	void (*me_func)(int, enum ev_type, void *);
 #define me_msecs me_fd
@@ -72,7 +70,6 @@ struct mevent {
 	int me_closefd;
 	LIST_ENTRY(mevent) me_list;
 };
-#pragma clang diagnostic pop
 
 static LIST_HEAD(listhead, mevent) global_head, change_head;
 

--- a/src/lib/pci_ahci.c
+++ b/src/lib/pci_ahci.c
@@ -116,8 +116,6 @@ static FILE *dbg;
 #endif
 #define WPRINTF(format, ...) printf(format, __VA_ARGS__)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 
 struct ahci_ioreq {
 	struct blockif_req io_req;
@@ -209,8 +207,6 @@ struct pci_ahci_softc {
 	uint32_t lintr;
 	struct ahci_port port[MAX_PORTS];
 };
-
-#pragma clang diagnostic pop
 
 static void ahci_handle_port(struct ahci_port *p);
 

--- a/src/lib/pci_emul.c
+++ b/src/lib/pci_emul.c
@@ -44,30 +44,30 @@
 #include <xhyve/pci_irq.h>
 #include <xhyve/pci_lpc.h>
 
-#define CONF1_ADDR_PORT 0x0cf8
-#define CONF1_DATA_PORT0 0x0cfc
-#define CONF1_DATA_PORT1 0x0cfd
-#define CONF1_DATA_PORT2 0x0cfe
-#define CONF1_DATA_PORT3 0x0cff
+#define CONF1_ADDR_PORT    0x0cf8
+#define CONF1_DATA_PORT0   0x0cfc
+#define CONF1_DATA_PORT1   0x0cfd
+#define CONF1_DATA_PORT2   0x0cfe
+#define CONF1_DATA_PORT3   0x0cff
 
-#define CONF1_ENABLE 0x80000000ul
+#define CONF1_ENABLE	   0x80000000ul
 
-#define	MAXBUSES (PCI_BUSMAX + 1)
-#define MAXSLOTS (PCI_SLOTMAX + 1)
-#define	MAXFUNCS (PCI_FUNCMAX + 1)
+#define	MAXBUSES	(PCI_BUSMAX + 1)
+#define MAXSLOTS	(PCI_SLOTMAX + 1)
+#define	MAXFUNCS	(PCI_FUNCMAX + 1)
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 struct funcinfo {
-	char *fi_name;
-	char *fi_param;
+	char	*fi_name;
+	char	*fi_param;
 	struct pci_devinst *fi_devi;
 };
 
 struct intxinfo {
-	int ii_count;
-	int ii_pirq_pin;
-	int ii_ioapic_irq;
+	int	ii_count;
+	int	ii_pirq_pin;
+	int	ii_ioapic_irq;
 };
 
 struct slotinfo {
@@ -76,9 +76,9 @@ struct slotinfo {
 };
 
 struct businfo {
-	uint16_t iobase, iolimit; /* I/O window */
-	uint32_t membase32, memlimit32; /* mmio window below 4GB */
-	uint64_t membase64, memlimit64; /* mmio window above 4GB */
+	uint16_t iobase, iolimit;		/* I/O window */
+	uint32_t membase32, memlimit32;		/* mmio window below 4GB */
+	uint64_t membase64, memlimit64;		/* mmio window above 4GB */
 	struct slotinfo slotinfo[MAXSLOTS];
 };
 #pragma clang diagnostic pop
@@ -114,9 +114,9 @@ CFGWRITE(struct pci_devinst *pi, int coff, uint32_t val, int bytes)
 {
 
 	if (bytes == 1)
-		pci_set_cfgdata8(pi, coff, ((uint8_t) val));
+		pci_set_cfgdata8(pi, coff, (uint8_t)val);
 	else if (bytes == 2)
-		pci_set_cfgdata16(pi, coff, ((uint16_t) val));
+		pci_set_cfgdata16(pi, coff, (uint16_t)val);
 	else
 		pci_set_cfgdata32(pi, coff, val);
 }
@@ -237,7 +237,7 @@ pci_valid_pba_offset(struct pci_devinst *pi, uint64_t offset)
 	if (offset < pi->pi_msix.pba_offset)
 		return (0);
 
-	if (offset >= pi->pi_msix.pba_offset + ((unsigned) pi->pi_msix.pba_size)) {
+	if (offset >= pi->pi_msix.pba_offset + (unsigned)pi->pi_msix.pba_size) {
 		return (0);
 	}
 
@@ -259,7 +259,7 @@ pci_emul_msix_twrite(struct pci_devinst *pi, uint64_t offset, int size,
 	/*
 	 * Return if table index is beyond what device supports
 	 */
-	tab_index = (int) (offset / MSIX_TABLE_ENTRY_SIZE);
+	tab_index = (int)(offset / MSIX_TABLE_ENTRY_SIZE);
 	if (tab_index >= pi->pi_msix.table_count)
 		return (-1);
 
@@ -273,9 +273,9 @@ pci_emul_msix_twrite(struct pci_devinst *pi, uint64_t offset, int size,
 	dest += msix_entry_offset;
 
 	if (size == 4)
-		*((uint32_t *)((void *) dest)) = (uint32_t) value;
+		*((uint32_t *)(void *)dest) = (uint32_t)value;
 	else
-		*((uint64_t *)((void *) dest)) = value;
+		*((uint64_t *)(void *)dest) = value;
 
 	return (0);
 }
@@ -286,11 +286,11 @@ pci_emul_msix_tread(struct pci_devinst *pi, uint64_t offset, int size)
 	char *dest;
 	int msix_entry_offset;
 	int tab_index;
-	uint64_t retval = ~((uint64_t) 0);
+	uint64_t retval = ~((uint64_t)0);
 
 	/*
 	 * The PCI standard only allows 4 and 8 byte accesses to the MSI-X
-	 * table but we also allow 1 byte access to accomodate reads from
+	 * table but we also allow 1 byte access to accommodate reads from
 	 * ddb.
 	 */
 	if (size != 1 && size != 4 && size != 8)
@@ -311,11 +311,11 @@ pci_emul_msix_tread(struct pci_devinst *pi, uint64_t offset, int size)
 		dest += msix_entry_offset;
 
 		if (size == 1)
-			retval = *((uint8_t *)((void *) dest));
+			retval = *((uint8_t *)(void *)dest);
 		else if (size == 4)
-			retval = *((uint32_t *)((void *) dest));
+			retval = *((uint32_t *)(void *)dest);
 		else
-			retval = *((uint64_t *)((void *) dest));
+			retval = *((uint64_t *)(void *)dest);
 	} else if (pci_valid_pba_offset(pi, offset)) {
 		/* return 0 for PBA access */
 		retval = 0;
@@ -354,14 +354,14 @@ pci_emul_io_handler(int vcpu, int in, int port, int bytes, uint32_t *eax,
 	int i;
 
 	for (i = 0; i <= PCI_BARMAX; i++) {
-		if ((pdi->pi_bar[i].type == PCIBAR_IO) &&
-		    (((uint64_t) port) >= pdi->pi_bar[i].addr) &&
-		    (((uint64_t) (port + bytes)) <=
-			(pdi->pi_bar[i].addr + pdi->pi_bar[i].size)))
+		if (pdi->pi_bar[i].type == PCIBAR_IO &&
+		    (uint64_t)port >= pdi->pi_bar[i].addr &&
+		    (uint64_t)(port + bytes) <=
+		        pdi->pi_bar[i].addr + pdi->pi_bar[i].size)
 		{
-			offset = ((uint64_t) port) - pdi->pi_bar[i].addr;
+			offset = (uint64_t)port - pdi->pi_bar[i].addr;
 			if (in)
-				*eax = (uint32_t) (*pe->pe_barread)(vcpu, pdi, i, offset,
+				*eax = (uint32_t)(*pe->pe_barread)(vcpu, pdi, i, offset,
 					bytes);
 			else
 				(*pe->pe_barwrite)(vcpu, pdi, i, offset, bytes, *eax);
@@ -381,11 +381,11 @@ pci_emul_mem_handler(int vcpu, int dir, uint64_t addr,
 	int bidx = (int) arg2;
 
 	assert(bidx <= PCI_BARMAX);
-	assert((pdi->pi_bar[bidx].type == PCIBAR_MEM32) ||
-		(pdi->pi_bar[bidx].type == PCIBAR_MEM64));
-	assert((addr >= pdi->pi_bar[bidx].addr) &&
-		((addr + ((uint64_t) size)) <=
-			(pdi->pi_bar[bidx].addr + pdi->pi_bar[bidx].size)));
+	assert(pdi->pi_bar[bidx].type == PCIBAR_MEM32 ||
+	       pdi->pi_bar[bidx].type == PCIBAR_MEM64);
+	assert(addr >= pdi->pi_bar[bidx].addr &&
+	       (addr + (uint64_t)size) <=
+			(pdi->pi_bar[bidx].addr + pdi->pi_bar[bidx].size));
 
 	offset = addr - pdi->pi_bar[bidx].addr;
 
@@ -450,7 +450,7 @@ modify_bar_registration(struct pci_devinst *pi, int idx, int registration)
 	case PCIBAR_IO:
 		bzero(&iop, sizeof(struct inout_port));
 		iop.name = pi->pi_name;
-		iop.port = (int) pi->pi_bar[idx].addr;
+		iop.port = (int)pi->pi_bar[idx].addr;
 		iop.size = (int)pi->pi_bar[idx].size;
 		if (registration) {
 			iop.flags = IOPORT_F_INOUT;
@@ -572,7 +572,7 @@ pci_emul_alloc_pbar(struct pci_devinst *pdi, int idx, uint64_t hostbase,
 	limit = 0;
 
 	if ((size & (size - 1)) != 0)
-		size = 1UL << flsl((long) size); /* round up to a power of 2 */
+		size = 1UL << flsll((long long)size); /* round up to a power of 2 */
 
 	/* Enforce minimum BAR sizes required by the PCI standard */
 	if (type == PCIBAR_IO) {
@@ -645,7 +645,7 @@ pci_emul_alloc_pbar(struct pci_devinst *pdi, int idx, uint64_t hostbase,
 
 	/* Initialize the BAR register in config space */
 	bar = (addr & mask) | lobits;
-	pci_set_cfgdata32(pdi, PCIR_BAR(idx), ((uint32_t) bar));
+	pci_set_cfgdata32(pdi, PCIR_BAR(idx), (uint32_t)bar);
 
 	if (type == PCIBAR_MEM64) {
 		assert(idx + 1 <= PCI_BARMAX);
@@ -681,10 +681,10 @@ pci_emul_add_capability(struct pci_devinst *pi, u_char *capdata, int caplen)
 
 	/* Set the previous capability pointer */
 	if ((sts & PCIM_STATUS_CAPPRESENT) == 0) {
-		pci_set_cfgdata8(pi, PCIR_CAP_PTR, ((uint8_t) capoff));
+		pci_set_cfgdata8(pi, PCIR_CAP_PTR, (uint8_t)capoff);
 		pci_set_cfgdata16(pi, PCIR_STATUS, sts|PCIM_STATUS_CAPPRESENT);
 	} else
-		pci_set_cfgdata8(pi, pi->pi_prevcap + 1, ((uint8_t) capoff));
+		pci_set_cfgdata8(pi, pi->pi_prevcap + 1, (uint8_t)capoff);
 
 	/* Copy the capability */
 	for (i = 0; i < caplen; i++)
@@ -722,9 +722,9 @@ pci_emul_init(struct pci_devemu *pde, int bus, int slot,
 
 	pdi = calloc(1, sizeof(struct pci_devinst));
 
-	pdi->pi_bus = (uint8_t) bus;
-	pdi->pi_slot = (uint8_t) slot;
-	pdi->pi_func = (uint8_t) func;
+	pdi->pi_bus = (uint8_t)bus;
+	pdi->pi_slot = (uint8_t)slot;
+	pdi->pi_func = (uint8_t)func;
 	pthread_mutex_init(&pdi->pi_lintr.lock, NULL);
 	pdi->pi_lintr.pin = 0;
 	pdi->pi_lintr.state = IDLE;
@@ -762,8 +762,8 @@ pci_populate_msicap(struct msicap *msicap, int msgnum, int nextptr)
 
 	bzero(msicap, sizeof(struct msicap));
 	msicap->capid = PCIY_MSI;
-	msicap->nextptr = (uint8_t) nextptr;
-	msicap->msgctrl = (uint16_t) (PCIM_MSICTRL_64BIT | (mmc << 1));
+	msicap->nextptr = (uint8_t)nextptr;
+	msicap->msgctrl = (uint16_t)(PCIM_MSICTRL_64BIT | (mmc << 1));
 }
 
 int
@@ -792,7 +792,7 @@ pci_populate_msixcap(struct msixcap *msixcap, int msgnum, int barnum,
 	 * zero except for the Table Size.
 	 * Note: Table size N is encoded as N-1
 	 */
-	msixcap->msgctrl = (uint16_t) (msgnum - 1);
+	msixcap->msgctrl = (uint16_t)msgnum - 1;
 
 	/*
 	 * MSI-X BAR setup:
@@ -812,7 +812,7 @@ pci_msix_table_init(struct pci_devinst *pi, int table_entries)
 	assert(table_entries <= MAX_MSIX_TABLE_ENTRIES);
 
 	table_size = table_entries * MSIX_TABLE_ENTRY_SIZE;
-	pi->pi_msix.table = calloc(1, ((size_t) table_size));
+	pi->pi_msix.table = calloc(1, (size_t)table_size);
 
 	/* set mask bit of vector control register */
 	for (i = 0; i < table_entries; i++)
@@ -828,7 +828,7 @@ pci_emul_add_msixcap(struct pci_devinst *pi, int msgnum, int barnum)
 	assert(msgnum >= 1 && msgnum <= MAX_MSIX_TABLE_ENTRIES);
 	assert(barnum >= 0 && barnum <= PCIR_MAX_BAR_0);
 
-	tab_size = (uint32_t) (msgnum * MSIX_TABLE_ENTRY_SIZE);
+	tab_size = (uint32_t)msgnum * MSIX_TABLE_ENTRY_SIZE;
 
 	/* Align table size to nearest 4K */
 	tab_size = roundup2(tab_size, 4096u);
@@ -846,7 +846,7 @@ pci_emul_add_msixcap(struct pci_devinst *pi, int msgnum, int barnum)
 
 	/* allocate memory for MSI-X Table and PBA */
 	pci_emul_alloc_bar(pi, barnum, PCIBAR_MEM32,
-		(tab_size + ((uint32_t) pi->pi_msix.pba_size)));
+			   tab_size + (uint32_t)pi->pi_msix.pba_size);
 
 	return (pci_emul_add_capability(pi, (u_char *)&msixcap,
 					sizeof(msixcap)));
@@ -1084,9 +1084,9 @@ init_pci(void)
 		 * Keep track of the i/o and memory resources allocated to
 		 * this bus.
 		 */
-		bi->iobase = (uint16_t) pci_emul_iobase;
-		bi->membase32 = (uint32_t) pci_emul_membase32;
-		bi->membase64 = (uint32_t) pci_emul_membase64;
+		bi->iobase = (uint16_t)pci_emul_iobase;
+		bi->membase32 = (uint32_t)pci_emul_membase32;
+		bi->membase64 = (uint32_t)pci_emul_membase64;
 
 		for (slot = 0; slot < MAXSLOTS; slot++) {
 			si = &bi->slotinfo[slot];
@@ -1108,17 +1108,17 @@ init_pci(void)
 		 * reprogram the BARs.
 		 */
 		pci_emul_iobase += BUSIO_ROUNDUP;
-		pci_emul_iobase = roundup2(pci_emul_iobase, ((uint32_t) BUSIO_ROUNDUP));
-		bi->iolimit = (uint16_t) pci_emul_iobase;
+		pci_emul_iobase = roundup2(pci_emul_iobase, (uint32_t)BUSIO_ROUNDUP);
+		bi->iolimit = (uint16_t)pci_emul_iobase;
 
 		pci_emul_membase32 += BUSMEM_ROUNDUP;
 		pci_emul_membase32 = roundup2(pci_emul_membase32,
-			((uint64_t) BUSMEM_ROUNDUP));
-		bi->memlimit32 = (uint32_t) pci_emul_membase32;
+		    (uint64_t)BUSMEM_ROUNDUP);
+		bi->memlimit32 = (uint32_t)pci_emul_membase32;
 
 		pci_emul_membase64 += BUSMEM_ROUNDUP;
 		pci_emul_membase64 = roundup2(pci_emul_membase64,
-			((uint64_t) BUSMEM_ROUNDUP));
+		    (uint64_t)BUSMEM_ROUNDUP);
 		bi->memlimit64 = pci_emul_membase64;
 	}
 
@@ -1480,8 +1480,8 @@ pci_generate_msi(struct pci_devinst *pi, int index)
 {
 
 	if (pci_msi_enabled(pi) && index < pci_msi_maxmsgnum(pi)) {
-		xh_vm_lapic_msi(pi->pi_msi.addr, pi->pi_msi.msg_data +
-			((uint64_t) index));
+		xh_vm_lapic_msi(pi->pi_msi.addr,
+				pi->pi_msi.msg_data + (uint64_t)index);
 	}
 }
 
@@ -1520,8 +1520,8 @@ pci_lintr_request(struct pci_devinst *pi)
 	}
 
 	si->si_intpins[bestpin].ii_count++;
-	pi->pi_lintr.pin = (int8_t) (bestpin + 1);
-	pci_set_cfgdata8(pi, PCIR_INTPIN, ((uint8_t) (bestpin + 1)));
+	pi->pi_lintr.pin = (int8_t)bestpin + 1;
+	pci_set_cfgdata8(pi, PCIR_INTPIN, (uint8_t)bestpin + 1);
 }
 
 static void
@@ -1555,7 +1555,7 @@ pci_lintr_route(struct pci_devinst *pi)
 
 	pi->pi_lintr.ioapic_irq = ii->ii_ioapic_irq;
 	pi->pi_lintr.pirq_pin = ii->ii_pirq_pin;
-	pci_set_cfgdata8(pi, PCIR_INTLINE, ((uint8_t) pirq_irq(ii->ii_pirq_pin)));
+	pci_set_cfgdata8(pi, PCIR_INTLINE, (uint8_t)pirq_irq(ii->ii_pirq_pin));
 }
 
 void
@@ -1683,13 +1683,13 @@ pci_emul_hdrtype_fixup(int bus, int slot, int off, int bytes, uint32_t *rv)
 		switch (bytes) {
 		case 1:
 		case 2:
-			*rv &= ~((uint32_t) PCIM_MFDEV);
+			*rv &= ~((uint32_t)PCIM_MFDEV);
 			if (mfdev) {
 				*rv |= PCIM_MFDEV;
 			}
 			break;
 		case 4:
-			*rv &= ~((uint32_t) (PCIM_MFDEV << 16));
+			*rv &= ~((uint32_t)PCIM_MFDEV << 16);
 			if (mfdev) {
 				*rv |= (PCIM_MFDEV << 16);
 			}
@@ -1888,7 +1888,7 @@ pci_cfgrw(int vcpu, int in, int bus, int slot, int func, int coff, int bytes,
 				}
 				break;
 			}
-			pci_set_cfgdata32(pi, coff, ((uint32_t) bar));
+			pci_set_cfgdata32(pi, coff, (uint32_t)bar);
 
 		} else if (pci_emul_iscap(pi, coff)) {
 			pci_emul_capwrite(pi, coff, bytes, *eax);
@@ -1915,7 +1915,7 @@ pci_emul_cfgaddr(UNUSED int vcpu, int in, UNUSED int port, int bytes,
 	}
 
 	if (in) {
-		x = (uint32_t) ((cfgbus << 16) | (cfgslot << 11) | (cfgfunc << 8) |
+		x = (uint32_t)((cfgbus << 16) | (cfgslot << 11) | (cfgfunc << 8) |
 			cfgoff);
 
 		if (cfgenable)
@@ -1964,8 +1964,8 @@ INOUT_PORT(pci_cfgdata, CONF1_DATA_PORT3, IOPORT_F_INOUT, pci_emul_cfgdata);
 /*
  * Define a dummy test device
  */
-#define DIOSZ 8
-#define DMEMSZ 4096
+#define DIOSZ	8
+#define DMEMSZ	4096
 struct pci_emul_dsoftc {
 	uint8_t   ioregs[DIOSZ];
 	uint8_t	  memregs[2][DMEMSZ];
@@ -2010,7 +2010,7 @@ pci_emul_diow(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 	struct pci_emul_dsoftc *sc = pi->pi_arg;
 
 	if (baridx == 0) {
-		if (offset + ((uint64_t) size) > DIOSZ) {
+		if (offset + (uint64_t)size > DIOSZ) {
 			printf("diow: iow too large, offset %llu size %d\n",
 			       offset, size);
 			return;
@@ -2019,9 +2019,9 @@ pci_emul_diow(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 		if (size == 1) {
 			sc->ioregs[offset] = value & 0xff;
 		} else if (size == 2) {
-			*(uint16_t *)((void *) &sc->ioregs[offset]) = value & 0xffff;
+			*(uint16_t *)(void *)&sc->ioregs[offset] = value & 0xffff;
 		} else if (size == 4) {
-			*(uint32_t *)((void *) &sc->ioregs[offset]) = (uint32_t) value;
+			*(uint32_t *)(void *)&sc->ioregs[offset] = (uint32_t)value;
 		} else {
 			printf("diow: iow unknown size %d\n", size);
 		}
@@ -2030,8 +2030,8 @@ pci_emul_diow(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 		 * Special magic value to generate an interrupt
 		 */
 		if (offset == 4 && size == 4 && pci_msi_enabled(pi))
-			pci_generate_msi(pi, ((int) (value %
-				((uint64_t) pci_msi_maxmsgnum(pi)))));
+			pci_generate_msi(pi, (int)(value %
+				(uint64_t)pci_msi_maxmsgnum(pi)));
 
 		if (value == 0xabcdef) {
 			for (i = 0; i < pci_msi_maxmsgnum(pi); i++)
@@ -2040,7 +2040,7 @@ pci_emul_diow(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 	}
 
 	if (baridx == 1 || baridx == 2) {
-		if (offset + ((uint16_t) size) > DMEMSZ) {
+		if (offset + (uint16_t)size > DMEMSZ) {
 			printf("diow: memw too large, offset %llu size %d\n",
 			       offset, size);
 			return;
@@ -2049,14 +2049,14 @@ pci_emul_diow(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 		i = baridx - 1;		/* 'memregs' index */
 
 		if (size == 1) {
-			sc->memregs[i][offset] = (uint8_t) value;
+			sc->memregs[i][offset] = (uint8_t)value;
 
 		} else if (size == 2) {
-			*(uint16_t *)((void *) &sc->memregs[i][offset]) = (uint16_t) value;
+			*(uint16_t *)(void *)&sc->memregs[i][offset] = (uint16_t) value;
 		} else if (size == 4) {
-			*(uint32_t *)((void *) &sc->memregs[i][offset]) = (uint32_t) value;
+			*(uint32_t *)(void *)&sc->memregs[i][offset] = (uint32_t)value;
 		} else if (size == 8) {
-			*(uint64_t *)((void *) &sc->memregs[i][offset]) = value;
+			*(uint64_t *)(void *)&sc->memregs[i][offset] = value;
 		} else {
 			printf("diow: memw unknown size %d\n", size);
 		}
@@ -2082,7 +2082,7 @@ pci_emul_dior(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 	value = 0;
 
 	if (baridx == 0) {
-		if (offset + ((uint64_t) size) > DIOSZ) {
+		if (offset + (uint64_t)size > DIOSZ) {
 			printf("dior: ior too large, offset %llu size %d\n",
 			       offset, size);
 			return (0);
@@ -2091,9 +2091,9 @@ pci_emul_dior(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 		if (size == 1) {
 			value = sc->ioregs[offset];
 		} else if (size == 2) {
-			value = *(uint16_t *)((void *) &sc->ioregs[offset]);
+			value = *(uint16_t *)(void *)&sc->ioregs[offset];
 		} else if (size == 4) {
-			value = *(uint32_t *)((void *) &sc->ioregs[offset]);
+			value = *(uint32_t *)(void *)&sc->ioregs[offset];
 		} else {
 			printf("dior: ior unknown size %d\n", size);
 		}
@@ -2111,11 +2111,11 @@ pci_emul_dior(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 		if (size == 1) {
 			value = sc->memregs[i][offset];
 		} else if (size == 2) {
-			value = *(uint16_t *) ((void *) &sc->memregs[i][offset]);
+			value = *(uint16_t *)(void *)&sc->memregs[i][offset];
 		} else if (size == 4) {
-			value = *(uint32_t *) ((void *) &sc->memregs[i][offset]);
+			value = *(uint32_t *)(void *)&sc->memregs[i][offset];
 		} else if (size == 8) {
-			value = (uint32_t) *(uint64_t *) ((void *) &sc->memregs[i][offset]);
+			value = (uint32_t) *(uint64_t *)(void *)&sc->memregs[i][offset];
 		} else {
 			printf("dior: ior unknown size %d\n", size);
 		}

--- a/src/lib/pci_emul.c
+++ b/src/lib/pci_emul.c
@@ -56,8 +56,6 @@
 #define MAXSLOTS	(PCI_SLOTMAX + 1)
 #define	MAXFUNCS	(PCI_FUNCMAX + 1)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct funcinfo {
 	char	*fi_name;
 	char	*fi_param;
@@ -81,7 +79,6 @@ struct businfo {
 	uint64_t membase64, memlimit64;		/* mmio window above 4GB */
 	struct slotinfo slotinfo[MAXSLOTS];
 };
-#pragma clang diagnostic pop
 
 static struct businfo *pci_businfo[MAXBUSES];
 

--- a/src/lib/pci_irq.c
+++ b/src/lib/pci_irq.c
@@ -59,9 +59,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 static struct pirq {
-	uint8_t reg;
-	int use_count;
-	int active_count;
+	uint8_t	reg;
+	int	use_count;
+	int	active_count;
 	pthread_mutex_t lock;
 } pirqs[8];
 #pragma clang diagnostic pop
@@ -77,6 +77,7 @@ static int pirq_cold = 1;
 static bool
 pirq_valid_irq(int reg)
 {
+
 	if (reg & PIRQ_DIS)
 		return (false);
 	return (IRQ_PERMITTED(reg & PIRQ_IRQ));
@@ -85,7 +86,7 @@ pirq_valid_irq(int reg)
 uint8_t
 pirq_read(int pin)
 {
-	assert((pin > 0) && (((unsigned) pin) <= nitems(pirqs)));
+	assert(pin > 0 && (unsigned)pin <= nitems(pirqs));
 	return (pirqs[pin - 1].reg);
 }
 
@@ -94,7 +95,7 @@ pirq_write(int pin, uint8_t val)
 {
 	struct pirq *pirq;
 
-	assert((pin > 0) && (((unsigned) pin) <= nitems(pirqs)));
+	assert(pin > 0 && (unsigned)pin <= nitems(pirqs));
 	pirq = &pirqs[pin - 1];
 	pthread_mutex_lock(&pirq->lock);
 	if (pirq->reg != (val & (PIRQ_DIS | PIRQ_IRQ))) {
@@ -110,7 +111,8 @@ pirq_write(int pin, uint8_t val)
 void
 pci_irq_reserve(int irq)
 {
-	assert((irq >= 0) && (((unsigned) irq) < nitems(irq_counts)));
+
+	assert(irq >= 0 && (unsigned)irq < nitems(irq_counts));
 	assert(pirq_cold);
 	assert(irq_counts[irq] == 0 || irq_counts[irq] == IRQ_DISABLED);
 	irq_counts[irq] = IRQ_DISABLED;
@@ -119,7 +121,8 @@ pci_irq_reserve(int irq)
 void
 pci_irq_use(int irq)
 {
-	assert((irq >= 0) && (((unsigned) irq) < nitems(irq_counts)));
+
+	assert(irq >= 0 && (unsigned)irq < nitems(irq_counts));
 	assert(pirq_cold);
 	assert(irq_counts[irq] != IRQ_DISABLED);
 	irq_counts[irq]++;
@@ -150,7 +153,7 @@ pci_irq_assert(struct pci_devinst *pi)
 	struct pirq *pirq;
 
 	if (pi->pi_lintr.pirq_pin > 0) {
-		assert(((unsigned) pi->pi_lintr.pirq_pin) <= nitems(pirqs));
+		assert((unsigned)pi->pi_lintr.pirq_pin <= nitems(pirqs));
 		pirq = &pirqs[pi->pi_lintr.pirq_pin - 1];
 		pthread_mutex_lock(&pirq->lock);
 		pirq->active_count++;
@@ -170,7 +173,7 @@ pci_irq_deassert(struct pci_devinst *pi)
 	struct pirq *pirq;
 
 	if (pi->pi_lintr.pirq_pin > 0) {
-		assert(((unsigned) pi->pi_lintr.pirq_pin) <= nitems(pirqs));
+		assert((unsigned)pi->pi_lintr.pirq_pin <= nitems(pirqs));
 		pirq = &pirqs[pi->pi_lintr.pirq_pin - 1];
 		pthread_mutex_lock(&pirq->lock);
 		pirq->active_count--;
@@ -195,7 +198,7 @@ pirq_alloc_pin(void)
 	/* First, find the least-used PIRQ pin. */
 	best_pin = 0;
 	best_count = pirqs[0].use_count;
-	for (pin = 1; ((unsigned) pin) < nitems(pirqs); pin++) {
+	for (pin = 1; (unsigned)pin < nitems(pirqs); pin++) {
 		if (pirqs[pin].use_count < best_count) {
 			best_pin = pin;
 			best_count = pirqs[pin].use_count;
@@ -207,7 +210,7 @@ pirq_alloc_pin(void)
 	if (pirqs[best_pin].reg == PIRQ_DIS) {
 		best_irq = -1;
 		best_count = 0;
-		for (irq = 0; ((unsigned) irq) < nitems(irq_counts); irq++) {
+		for (irq = 0; (unsigned)irq < nitems(irq_counts); irq++) {
 			if (irq_counts[irq] == IRQ_DISABLED)
 				continue;
 			if (best_irq == -1 || irq_counts[irq] < best_count) {
@@ -217,7 +220,7 @@ pirq_alloc_pin(void)
 		}
 		assert(best_irq >= 0);
 		irq_counts[best_irq]++;
-		pirqs[best_pin].reg = (uint8_t) best_irq;
+		pirqs[best_pin].reg = (uint8_t)best_irq;
 		xh_vm_isa_set_irq_trigger(best_irq, LEVEL_TRIGGER);
 	}
 
@@ -227,7 +230,7 @@ pirq_alloc_pin(void)
 int
 pirq_irq(int pin)
 {
-	assert((pin > 0) && (((unsigned) pin) <= nitems(pirqs)));
+	assert(pin > 0 && (unsigned)pin <= nitems(pirqs));
 	return (pirqs[pin - 1].reg & PIRQ_IRQ);
 }
 
@@ -240,7 +243,7 @@ pirq_dsdt(void)
 	int irq, pin;
 
 	irq_prs = NULL;
-	for (irq = 0; ((unsigned) irq) < nitems(irq_counts); irq++) {
+	for (irq = 0; (unsigned)irq < nitems(irq_counts); irq++) {
 		if (!IRQ_PERMITTED(irq))
 			continue;
 		if (irq_prs == NULL)
@@ -279,7 +282,7 @@ pirq_dsdt(void)
 	dsdt_line("  Return (0x01)");
 	dsdt_line("}");
 
-	for (pin = 0; ((unsigned) pin) < nitems(pirqs); pin++) {
+	for (pin = 0; (unsigned)pin < nitems(pirqs); pin++) {
 		dsdt_line("");
 		dsdt_line("Device (LNK%c)", 'A' + pin);
 		dsdt_line("{");

--- a/src/lib/pci_irq.c
+++ b/src/lib/pci_irq.c
@@ -56,15 +56,12 @@
 /* IRQ count to disable an IRQ. */
 #define	IRQ_DISABLED	0xff
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 static struct pirq {
 	uint8_t	reg;
 	int	use_count;
 	int	active_count;
 	pthread_mutex_t lock;
 } pirqs[8];
-#pragma clang diagnostic pop
 
 static u_char irq_counts[16];
 static int pirq_cold = 1;

--- a/src/lib/pci_lpc.c
+++ b/src/lib/pci_lpc.c
@@ -58,8 +58,6 @@ static struct pci_devinst *lpc_bridge;
 
 #define	LPC_UART_NUM	2
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 static struct lpc_uart_softc {
 	struct uart_softc *uart_softc;
 	const char *opts;
@@ -68,7 +66,6 @@ static struct lpc_uart_softc {
 	int	irq;
 	int	enabled;
 } lpc_uart_softc[LPC_UART_NUM];
-#pragma clang diagnostic pop
 
 static const char *lpc_uart_names[LPC_UART_NUM] = { "COM1", "COM2" };
 

--- a/src/lib/pci_lpc.c
+++ b/src/lib/pci_lpc.c
@@ -137,15 +137,15 @@ lpc_uart_io_handler(UNUSED int vcpu, int in, int port, int bytes, uint32_t *eax,
 		if (in)
 			*eax = uart_read(sc->uart_softc, offset);
 		else
-			uart_write(sc->uart_softc, offset, ((uint8_t) *eax));
+			uart_write(sc->uart_softc, offset, (uint8_t)*eax);
 		break;
 	case 2:
 		if (in) {
-			*eax = (uint32_t) uart_read(sc->uart_softc, offset);
-			*eax |= (uint32_t) (uart_read(sc->uart_softc, offset + 1) << 8);
+			*eax = (uint32_t)uart_read(sc->uart_softc, offset);
+			*eax |= (uint32_t)(uart_read(sc->uart_softc, offset + 1) << 8);
 		} else {
-			uart_write(sc->uart_softc, offset, ((uint8_t) *eax));
-			uart_write(sc->uart_softc, offset + 1, ((uint8_t) (*eax >> 8)));
+			uart_write(sc->uart_softc, offset, (uint8_t)*eax);
+			uart_write(sc->uart_softc, offset + 1, (uint8_t)(*eax >> 8));
 		}
 		break;
 	default:
@@ -277,7 +277,8 @@ pci_lpc_sysres_dsdt(void)
 		lsp = *lspp;
 		switch (lsp->type) {
 		case LPC_SYSRES_IO:
-			dsdt_fixed_ioport(((uint16_t) lsp->base), ((uint16_t) lsp->length));
+			dsdt_fixed_ioport((uint16_t)lsp->base,
+					  (uint16_t)lsp->length);
 			break;
 		case LPC_SYSRES_MEM:
 			dsdt_fixed_mem32(lsp->base, lsp->length);
@@ -309,8 +310,8 @@ pci_lpc_uart_dsdt(void)
 		dsdt_line("  Name (_CRS, ResourceTemplate ()");
 		dsdt_line("  {");
 		dsdt_indent(2);
-		dsdt_fixed_ioport(((uint16_t) sc->iobase), UART_IO_BAR_SIZE);
-		dsdt_fixed_irq(((uint8_t) sc->irq));
+		dsdt_fixed_ioport((uint16_t)sc->iobase, UART_IO_BAR_SIZE);
+		dsdt_fixed_irq((uint8_t) sc->irq);
 		dsdt_unindent(2);
 		dsdt_line("  })");
 		dsdt_line("}");
@@ -331,7 +332,7 @@ pci_lpc_cfgwrite(UNUSED int vcpu, struct pci_devinst *pi, int coff, int bytes,
 		if (coff >= 0x68 && coff <= 0x6b)
 			pirq_pin = coff - 0x68 + 5;
 		if (pirq_pin != 0) {
-			pirq_write(pirq_pin, ((uint8_t) val));
+			pirq_write(pirq_pin, (uint8_t)val);
 			pci_set_cfgdata8(pi, coff, pirq_read(pirq_pin));
 			return (0);
 		}

--- a/src/lib/pci_uart.c
+++ b/src/lib/pci_uart.c
@@ -66,7 +66,7 @@ pci_uart_write(UNUSED int vcpu, struct pci_devinst *pi, int baridx, uint64_t off
 	assert(baridx == 0);
 	assert(size == 1);
 
-	uart_write(pi->pi_arg, ((int) offset), ((uint8_t) value));
+	uart_write(pi->pi_arg, (int)offset, (uint8_t)value);
 }
 
 static uint64_t
@@ -78,7 +78,7 @@ pci_uart_read(UNUSED int vcpu, struct pci_devinst *pi, int baridx,
 	assert(baridx == 0);
 	assert(size == 1);
 
-	val = uart_read(pi->pi_arg, ((int) offset));
+	val = uart_read(pi->pi_arg, (int)offset);
 	return (val);
 }
 

--- a/src/lib/pci_virtio_9p.c
+++ b/src/lib/pci_virtio_9p.c
@@ -35,8 +35,6 @@ struct virtio_9p_config {
 /*
  * Per-device softc
  */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct pci_vt9p_out {
 	struct iovec wiov[MAXDESC];
 	struct vqueue_info *vq;
@@ -59,7 +57,6 @@ struct pci_vt9p_softc {
 	int port;
 	char *path;
 };
-#pragma clang diagnostic pop
 
 static void pci_vt9p_reset(void *);
 static void pci_vt9p_notify(void *, struct vqueue_info *);

--- a/src/lib/pci_virtio_block.c
+++ b/src/lib/pci_virtio_block.c
@@ -74,8 +74,6 @@
     VTBLK_F_TOPOLOGY |						    \
     VIRTIO_RING_F_INDIRECT_DESC )	/* indirect descriptors */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
 /*
  * Config space "registers"
  */
@@ -112,8 +110,6 @@ struct virtio_blk_hdr {
 	uint32_t	vbh_ioprio;
 	uint64_t	vbh_sector;
 } __packed;
-
-#pragma clang diagnostic pop
 
 /*
  * Debug printf

--- a/src/lib/pci_virtio_block.c
+++ b/src/lib/pci_virtio_block.c
@@ -50,29 +50,29 @@
 #include <xhyve/virtio.h>
 #include <xhyve/block_if.h>
 
-#define VTBLK_RINGSZ 128
+#define VTBLK_RINGSZ    128
 
-#define VTBLK_S_OK 0
-#define VTBLK_S_IOERR 1
-#define	VTBLK_S_UNSUPP 2
+#define VTBLK_S_OK	0
+#define VTBLK_S_IOERR	1
+#define	VTBLK_S_UNSUPP	2
 
 #define	VTBLK_BLK_ID_BYTES 20 + 1
 
 /* Capability bits */
-#define	VTBLK_F_SEG_MAX (1 << 2) /* Maximum request segments */
-#define	VTBLK_F_BLK_SIZE (1 << 6) /* cfg block size valid */
-#define	VTBLK_F_FLUSH (1 << 9) /* Cache flush support */
-#define	VTBLK_F_TOPOLOGY (1 << 10) /* Optimal I/O alignment */
+#define	VTBLK_F_SEG_MAX		(1 << 2)	/* Maximum request segments */
+#define	VTBLK_F_BLK_SIZE	(1 << 6)	/* cfg block size valid */
+#define	VTBLK_F_FLUSH		(1 << 9)	/* Cache flush support */
+#define	VTBLK_F_TOPOLOGY	(1 << 10)	/* Optimal I/O alignment */
 
 /*
  * Host capabilities
  */
-#define VTBLK_S_HOSTCAPS \
-	(VTBLK_F_SEG_MAX  | \
-	 VTBLK_F_BLK_SIZE | \
-	 VTBLK_F_FLUSH    | \
-	 VTBLK_F_TOPOLOGY | \
-	 VIRTIO_RING_F_INDIRECT_DESC) /* indirect descriptors */
+#define VTBLK_S_HOSTCAPS      \
+  ( VTBLK_F_SEG_MAX  |						    \
+    VTBLK_F_BLK_SIZE |						    \
+    VTBLK_F_FLUSH    |						    \
+    VTBLK_F_TOPOLOGY |						    \
+    VIRTIO_RING_F_INDIRECT_DESC )	/* indirect descriptors */
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpacked"
@@ -80,22 +80,22 @@
  * Config space "registers"
  */
 struct vtblk_config {
-	uint64_t vbc_capacity;
-	uint32_t vbc_size_max;
-	uint32_t vbc_seg_max;
+	uint64_t	vbc_capacity;
+	uint32_t	vbc_size_max;
+	uint32_t	vbc_seg_max;
 	struct {
 		uint16_t cylinders;
 		uint8_t heads;
 		uint8_t sectors;
 	} vbc_geometry;
-	uint32_t vbc_blk_size;
+	uint32_t	vbc_blk_size;
 	struct {
 		uint8_t physical_block_exp;
 		uint8_t alignment_offset;
 		uint16_t min_io_size;
 		uint32_t opt_io_size;
 	} vbc_topology;
-	uint8_t vbc_writeback;
+	uint8_t		vbc_writeback;
 } __packed;
 
 /*
@@ -108,9 +108,9 @@ struct virtio_blk_hdr {
 #define	VBH_OP_FLUSH_OUT	5
 #define	VBH_OP_IDENT		8
 #define	VBH_FLAG_BARRIER	0x80000000	/* OR'ed into vbh_type */
-	uint32_t vbh_type;
-	uint32_t vbh_ioprio;
-	uint64_t vbh_sector;
+	uint32_t       	vbh_type;
+	uint32_t	vbh_ioprio;
+	uint64_t	vbh_sector;
 } __packed;
 
 #pragma clang diagnostic pop
@@ -124,10 +124,10 @@ static int pci_vtblk_debug;
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpadded"
 struct pci_vtblk_ioreq {
-	struct blockif_req io_req;
-	struct pci_vtblk_softc *io_sc;
-	uint8_t *io_status;
-	uint16_t io_idx;
+	struct blockif_req		io_req;
+	struct pci_vtblk_softc	       *io_sc;
+	uint8_t			       *io_status;
+	uint16_t			io_idx;
 };
 
 /*
@@ -151,15 +151,15 @@ static int pci_vtblk_cfgread(void *, int, int, uint32_t *);
 static int pci_vtblk_cfgwrite(void *, int, int, uint32_t);
 
 static struct virtio_consts vtblk_vi_consts = {
-	"vtblk", /* our name */
-	1, /* we support 1 virtqueue */
+	"vtblk",		/* our name */
+	1,			/* we support 1 virtqueue */
 	sizeof(struct vtblk_config), /* config reg size */
-	pci_vtblk_reset, /* reset */
-	pci_vtblk_notify, /* device-wide qnotify */
-	pci_vtblk_cfgread, /* read PCI config */
-	pci_vtblk_cfgwrite, /* write PCI config */
-	NULL, /* apply negotiated features */
-	VTBLK_S_HOSTCAPS, /* our capabilities */
+	pci_vtblk_reset,	/* reset */
+	pci_vtblk_notify,	/* device-wide qnotify */
+	pci_vtblk_cfgread,	/* read PCI config */
+	pci_vtblk_cfgwrite,	/* write PCI config */
+	NULL,			/* apply negotiated features */
+	VTBLK_S_HOSTCAPS,	/* our capabilities */
 };
 
 static void
@@ -238,9 +238,9 @@ pci_vtblk_proc(struct pci_vtblk_softc *sc, struct vqueue_info *vq)
 	assert(iov[0].iov_len == sizeof(struct virtio_blk_hdr));
 	vbh = iov[0].iov_base;
 	memcpy(&io->io_req.br_iov, &iov[1],
-		sizeof(struct iovec) * (((size_t) n) - 2));
+	       sizeof(struct iovec) * ((size_t)n - 2));
 	io->io_req.br_iovcnt = n - 2;
-	io->io_req.br_offset = (off_t) (vbh->vbh_sector * DEV_BSIZE);
+	io->io_req.br_offset = (off_t)(vbh->vbh_sector * DEV_BSIZE);
 	io->io_status = iov[--n].iov_base;
 	assert(iov[n].iov_len == 1);
 	assert(flags[n] & VRING_DESC_F_WRITE);
@@ -343,7 +343,7 @@ pci_vtblk_init(struct pci_devinst *pi, char *opts)
 		io->io_req.br_callback = pci_vtblk_done;
 		io->io_req.br_param = io;
 		io->io_sc = sc;
-		io->io_idx = (uint16_t) i;
+		io->io_idx = (uint16_t)i;
 	}
 
 	pthread_mutex_init(&sc->vsc_mtx, NULL);
@@ -360,24 +360,24 @@ pci_vtblk_init(struct pci_devinst *pi, char *opts)
 	 * md5 sum of the filename
 	 */
 	MD5Init(&mdctx);
-	MD5Update(&mdctx, opts, ((unsigned) strlen(opts)));
+	MD5Update(&mdctx, opts, (unsigned)strlen(opts));
 	MD5Final(digest, &mdctx);
 	snprintf(sc->vbsc_ident, VTBLK_BLK_ID_BYTES, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
 	    digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]);
 
 	/* setup virtio block config space */
 	sc->vbsc_cfg.vbc_capacity =
-		(uint64_t) (size / DEV_BSIZE); /* 512-byte units */
+		(uint64_t)(size / DEV_BSIZE); /* 512-byte units */
 	sc->vbsc_cfg.vbc_size_max = 0;	/* not negotiated */
 	sc->vbsc_cfg.vbc_seg_max = BLOCKIF_IOV_MAX;
 	sc->vbsc_cfg.vbc_geometry.cylinders = 0;	/* no geometry */
 	sc->vbsc_cfg.vbc_geometry.heads = 0;
 	sc->vbsc_cfg.vbc_geometry.sectors = 0;
-	sc->vbsc_cfg.vbc_blk_size = (uint32_t) sectsz;
+	sc->vbsc_cfg.vbc_blk_size = (uint32_t)sectsz;
 	sc->vbsc_cfg.vbc_topology.physical_block_exp =
-	    (uint8_t) ((sts > sectsz) ? (ffsll(sts / sectsz) - 1) : 0);
+	    (uint8_t)((sts > sectsz) ? (ffsll(sts / sectsz) - 1) : 0);
 	sc->vbsc_cfg.vbc_topology.alignment_offset =
-	    (uint8_t) ((sto != 0) ? ((sts - sto) / sectsz) : 0);
+	    (uint8_t)((sto != 0) ? ((sts - sto) / sectsz) : 0);
 	sc->vbsc_cfg.vbc_topology.min_io_size = 0;
 	sc->vbsc_cfg.vbc_topology.opt_io_size = 0;
 	sc->vbsc_cfg.vbc_writeback = 0;

--- a/src/lib/pci_virtio_block.c
+++ b/src/lib/pci_virtio_block.c
@@ -121,8 +121,6 @@ struct virtio_blk_hdr {
 static int pci_vtblk_debug;
 #define DPRINTF(params) if (pci_vtblk_debug) printf params
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct pci_vtblk_ioreq {
 	struct blockif_req		io_req;
 	struct pci_vtblk_softc	       *io_sc;
@@ -142,8 +140,6 @@ struct pci_vtblk_softc {
 	char vbsc_ident[VTBLK_BLK_ID_BYTES];
 	struct pci_vtblk_ioreq vbsc_ios[VTBLK_RINGSZ];
 };
-
-#pragma clang diagnostic pop
 
 static void pci_vtblk_reset(void *);
 static void pci_vtblk_notify(void *, struct vqueue_info *);

--- a/src/lib/pci_virtio_net_tap.c
+++ b/src/lib/pci_virtio_net_tap.c
@@ -59,24 +59,25 @@
 /*
  * Host capabilities.  Note that we only offer a few of these.
  */
-// #define VIRTIO_NET_F_CSUM (1 << 0) /* host handles partial cksum */
-// #define VIRTIO_NET_F_GUEST_CSUM (1 << 1) /* guest handles partial cksum */
-#define VIRTIO_NET_F_MAC (1 << 5) /* host supplies MAC */
-// #define VIRTIO_NET_F_GSO_DEPREC (1 << 6) /* deprecated: host handles GSO */
-// #define VIRTIO_NET_F_GUEST_TSO4 (1 << 7) /* guest can rcv TSOv4 */
-// #define VIRTIO_NET_F_GUEST_TSO6 (1 << 8) /* guest can rcv TSOv6 */
-// #define VIRTIO_NET_F_GUEST_ECN (1 << 9) /* guest can rcv TSO with ECN */
-// #define VIRTIO_NET_F_GUEST_UFO (1 << 10) /* guest can rcv UFO */
-// #define VIRTIO_NET_F_HOST_TSO4 (1 << 11) /* host can rcv TSOv4 */
-// #define VIRTIO_NET_F_HOST_TSO6 (1 << 12) /* host can rcv TSOv6 */
-// #define VIRTIO_NET_F_HOST_ECN (1 << 13) /* host can rcv TSO with ECN */
-// #define VIRTIO_NET_F_HOST_UFO (1 << 14) /* host can rcv UFO */
-#define VIRTIO_NET_F_MRG_RXBUF (1 << 15) /* host can merge RX buffers */
-#define VIRTIO_NET_F_STATUS (1 << 16) /* config status field available */
-// #define VIRTIO_NET_F_CTRL_VQ (1 << 17) /* control channel available */
-// #define VIRTIO_NET_F_CTRL_RX (1 << 18) /* control channel RX mode support */
-// #define VIRTIO_NET_F_CTRL_VLAN (1 << 19) /* control channel VLAN filtering */
-// #define VIRTIO_NET_F_GUEST_ANNOUNCE (1 << 21) /* guest can send gratuit. pkts */
+#define	VIRTIO_NET_F_CSUM	(1 <<  0) /* host handles partial cksum */
+#define	VIRTIO_NET_F_GUEST_CSUM	(1 <<  1) /* guest handles partial cksum */
+#define	VIRTIO_NET_F_MAC	(1 <<  5) /* host supplies MAC */
+#define	VIRTIO_NET_F_GSO_DEPREC	(1 <<  6) /* deprecated: host handles GSO */
+#define	VIRTIO_NET_F_GUEST_TSO4	(1 <<  7) /* guest can rcv TSOv4 */
+#define	VIRTIO_NET_F_GUEST_TSO6	(1 <<  8) /* guest can rcv TSOv6 */
+#define	VIRTIO_NET_F_GUEST_ECN	(1 <<  9) /* guest can rcv TSO with ECN */
+#define	VIRTIO_NET_F_GUEST_UFO	(1 << 10) /* guest can rcv UFO */
+#define	VIRTIO_NET_F_HOST_TSO4	(1 << 11) /* host can rcv TSOv4 */
+#define	VIRTIO_NET_F_HOST_TSO6	(1 << 12) /* host can rcv TSOv6 */
+#define	VIRTIO_NET_F_HOST_ECN	(1 << 13) /* host can rcv TSO with ECN */
+#define	VIRTIO_NET_F_HOST_UFO	(1 << 14) /* host can rcv UFO */
+#define	VIRTIO_NET_F_MRG_RXBUF	(1 << 15) /* host can merge RX buffers */
+#define	VIRTIO_NET_F_STATUS	(1 << 16) /* config status field available */
+#define	VIRTIO_NET_F_CTRL_VQ	(1 << 17) /* control channel available */
+#define	VIRTIO_NET_F_CTRL_RX	(1 << 18) /* control channel RX mode support */
+#define	VIRTIO_NET_F_CTRL_VLAN	(1 << 19) /* control channel VLAN filtering */
+#define	VIRTIO_NET_F_GUEST_ANNOUNCE \
+				(1 << 21) /* guest can send gratuitous pkts */
 
 #define VTNET_S_HOSTCAPS \
 	(VIRTIO_NET_F_MAC | VIRTIO_NET_F_MRG_RXBUF | VIRTIO_NET_F_STATUS | \
@@ -98,22 +99,23 @@ struct virtio_net_config {
 /*
  * Queue definitions.
  */
-#define VTNET_RXQ 0
-#define VTNET_TXQ 1
-// #define VTNET_CTLQ 2 /* NB: not yet supported */
-#define VTNET_MAXQ 3
+#define VTNET_RXQ	0
+#define VTNET_TXQ	1
+#define VTNET_CTLQ	2	/* NB: not yet supported */
+
+#define VTNET_MAXQ	3
 
 /*
  * Fixed network header size
  */
 struct virtio_net_rxhdr {
-	uint8_t vrh_flags;
-	uint8_t vrh_gso_type;
-	uint16_t vrh_hdr_len;
-	uint16_t vrh_gso_size;
-	uint16_t vrh_csum_start;
-	uint16_t vrh_csum_offset;
-	uint16_t vrh_bufs;
+	uint8_t		vrh_flags;
+	uint8_t		vrh_gso_type;
+	uint16_t	vrh_hdr_len;
+	uint16_t	vrh_gso_size;
+	uint16_t	vrh_csum_start;
+	uint16_t	vrh_csum_offset;
+	uint16_t	vrh_bufs;
 } __packed;
 
 #pragma clang diagnostic pop
@@ -134,20 +136,26 @@ struct pci_vtnet_softc {
 	struct virtio_softc vsc_vs;
 	struct vqueue_info vsc_queues[VTNET_MAXQ - 1];
 	pthread_mutex_t vsc_mtx;
-	struct mevent *vsc_mevp;
-	int vsc_tapfd;
-	int vsc_rx_ready;
-	volatile int resetting;/* set and checked outside lock */
-	uint64_t vsc_features; /* negotiated features */
+	struct mevent	*vsc_mevp;
+
+	int		vsc_tapfd;
+
+	int		vsc_rx_ready;
+	volatile int	resetting;	/* set and checked outside lock */
+
+	uint64_t	vsc_features;	/* negotiated features */
+
 	struct virtio_net_config vsc_config;
-	pthread_mutex_t rx_mtx;
-	int rx_in_progress;
-	int rx_vhdrlen;
-	int rx_merge; /* merged rx bufs in use */
-	pthread_t tx_tid;
-	pthread_mutex_t tx_mtx;
-	pthread_cond_t tx_cond;
-	int tx_in_progress;
+
+	pthread_mutex_t	rx_mtx;
+	int		rx_in_progress;
+	int		rx_vhdrlen;
+	int		rx_merge;	/* merged rx bufs in use */
+
+	pthread_t 	tx_tid;
+	pthread_mutex_t	tx_mtx;
+	pthread_cond_t	tx_cond;
+	int		tx_in_progress;
 };
 #pragma clang diagnostic pop
 
@@ -246,7 +254,7 @@ pci_vtnet_tap_tx(struct pci_vtnet_softc *sc, struct iovec *iov, int iovcnt,
 	 */
 	if (len < 60) {
 		iov[iovcnt].iov_base = pad;
-		iov[iovcnt].iov_len = (size_t) (60 - len);
+		iov[iovcnt].iov_len = (size_t)(60 - len);
 		iovcnt++;
 	}
 	(void) writev(sc->vsc_tapfd, iov, iovcnt);
@@ -267,16 +275,16 @@ rx_iov_trim(struct iovec *iov, int *niov, int tlen)
 	struct iovec *riov;
 
 	/* XXX short-cut: assume first segment is >= tlen */
-	assert(iov[0].iov_len >= ((size_t) tlen));
+	assert(iov[0].iov_len >= (size_t)tlen);
 
-	iov[0].iov_len -= ((size_t) tlen);
+	iov[0].iov_len -= (size_t)tlen;
 	if (iov[0].iov_len == 0) {
 		assert(*niov > 1);
 		*niov -= 1;
 		riov = &iov[1];
 	} else {
 		iov[0].iov_base = (void *)((uintptr_t)iov[0].iov_base +
-			((size_t) tlen));
+			(size_t)tlen);
 		riov = &iov[0];
 	}
 
@@ -365,7 +373,7 @@ pci_vtnet_tap_rx(struct pci_vtnet_softc *sc)
 		/*
 		 * Release this chain and handle more chains.
 		 */
-		vq_relchain(vq, idx, ((uint32_t) (len + sc->rx_vhdrlen)));
+		vq_relchain(vq, idx, (uint32_t)(len + sc->rx_vhdrlen));
 	} while (vq_has_descs(vq));
 
 	/* Interrupt if needed, including for NOTIFY_ON_EMPTY. */
@@ -449,7 +457,7 @@ pci_vtnet_proctx(struct pci_vtnet_softc *sc, struct vqueue_info *vq)
 	n = vq_getchain(vq, &idx, iov, VTNET_MAXSEGS, NULL);
 	assert(n >= 1 && n <= VTNET_MAXSEGS);
 	plen = 0;
-	tlen = (int) iov[0].iov_len;
+	tlen = (int)iov[0].iov_len;
 	for (i = 1; i < n; i++) {
 		plen += iov[i].iov_len;
 		tlen += iov[i].iov_len;
@@ -459,7 +467,7 @@ pci_vtnet_proctx(struct pci_vtnet_softc *sc, struct vqueue_info *vq)
 	pci_vtnet_tap_tx(sc, &iov[1], n - 1, plen);
 
 	/* chain is processed, release it and set tlen */
-	vq_relchain(vq, idx, ((uint32_t) tlen));
+	vq_relchain(vq, idx, (uint32_t)tlen);
 }
 
 static void
@@ -672,7 +680,7 @@ pci_vtnet_init(struct pci_devinst *pi, char *opts)
 		    pi->pi_func, vmname);
 
 		MD5Init(&mdctx);
-		MD5Update(&mdctx, nstr, ((unsigned int) strlen(nstr)));
+		MD5Update(&mdctx, nstr, (unsigned int)strlen(nstr));
 		MD5Final(digest, &mdctx);
 
 		sc->vsc_config.mac[0] = 0x00;

--- a/src/lib/pci_virtio_net_tap.c
+++ b/src/lib/pci_virtio_net_tap.c
@@ -127,8 +127,6 @@ static int pci_vtnet_debug;
 #define DPRINTF(params) if (pci_vtnet_debug) printf params
 #define WPRINTF(params) printf params
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 /*
  * Per-device softc
  */
@@ -157,7 +155,6 @@ struct pci_vtnet_softc {
 	pthread_cond_t	tx_cond;
 	int		tx_in_progress;
 };
-#pragma clang diagnostic pop
 
 static void pci_vtnet_reset(void *);
 /* static void pci_vtnet_notify(void *, struct vqueue_info *); */

--- a/src/lib/pci_virtio_net_tap.c
+++ b/src/lib/pci_virtio_net_tap.c
@@ -85,9 +85,6 @@
 
 #define ETHER_IS_MULTICAST(addr) (*(addr) & 0x01) /* is address mcast/bcast? */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
-
 /*
  * PCI config-space "registers"
  */
@@ -117,8 +114,6 @@ struct virtio_net_rxhdr {
 	uint16_t	vrh_csum_offset;
 	uint16_t	vrh_bufs;
 } __packed;
-
-#pragma clang diagnostic pop
 
 /*
  * Debug printf

--- a/src/lib/pci_virtio_net_vmnet.c
+++ b/src/lib/pci_virtio_net_vmnet.c
@@ -146,8 +146,6 @@ struct virtio_net_rxhdr {
 static int pci_vtnet_debug;
 #define DPRINTF(params) if (pci_vtnet_debug) printf params
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 /*
  * Per-device softc
  */
@@ -199,8 +197,6 @@ struct vmnet_state {
 	unsigned int mtu;
 	unsigned int max_packet_size;
 };
-
-#pragma clang diagnostic pop
 
 static void pci_vtnet_tap_callback(struct pci_vtnet_softc *sc);
 

--- a/src/lib/pci_virtio_net_vmnet.c
+++ b/src/lib/pci_virtio_net_vmnet.c
@@ -105,9 +105,6 @@
 	(VIRTIO_NET_F_MAC | VIRTIO_NET_F_MRG_RXBUF | VIRTIO_NET_F_STATUS | \
 	VIRTIO_F_NOTIFY_ON_EMPTY)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
-
 /*
  * PCI config-space "registers"
  */
@@ -137,8 +134,6 @@ struct virtio_net_rxhdr {
 	uint16_t	vrh_csum_offset;
 	uint16_t	vrh_bufs;
 } __packed;
-
-#pragma clang diagnostic pop
 
 /*
  * Debug printf

--- a/src/lib/pci_virtio_net_vmnet.c
+++ b/src/lib/pci_virtio_net_vmnet.c
@@ -81,30 +81,29 @@
 /*
  * Host capabilities.  Note that we only offer a few of these.
  */
-// #define VIRTIO_NET_F_CSUM (1 << 0) /* host handles partial cksum */
-// #define VIRTIO_NET_F_GUEST_CSUM (1 << 1) /* guest handles partial cksum */
-#define VIRTIO_NET_F_MAC (1 << 5) /* host supplies MAC */
-// #define VIRTIO_NET_F_GSO_DEPREC (1 << 6) /* deprecated: host handles GSO */
-// #define VIRTIO_NET_F_GUEST_TSO4 (1 << 7) /* guest can rcv TSOv4 */
-// #define VIRTIO_NET_F_GUEST_TSO6 (1 << 8) /* guest can rcv TSOv6 */
-// #define VIRTIO_NET_F_GUEST_ECN (1 << 9) /* guest can rcv TSO with ECN */
-// #define VIRTIO_NET_F_GUEST_UFO (1 << 10) /* guest can rcv UFO */
-// #define VIRTIO_NET_F_HOST_TSO4 (1 << 11) /* host can rcv TSOv4 */
-// #define VIRTIO_NET_F_HOST_TSO6 (1 << 12) /* host can rcv TSOv6 */
-// #define VIRTIO_NET_F_HOST_ECN (1 << 13) /* host can rcv TSO with ECN */
-// #define VIRTIO_NET_F_HOST_UFO (1 << 14) /* host can rcv UFO */
-#define VIRTIO_NET_F_MRG_RXBUF (1 << 15) /* host can merge RX buffers */
-#define VIRTIO_NET_F_STATUS (1 << 16) /* config status field available */
-// #define VIRTIO_NET_F_CTRL_VQ (1 << 17) /* control channel available */
-// #define VIRTIO_NET_F_CTRL_RX (1 << 18) /* control channel RX mode support */
-// #define VIRTIO_NET_F_CTRL_VLAN (1 << 19) /* control channel VLAN filtering */
-// #define VIRTIO_NET_F_GUEST_ANNOUNCE (1 << 21) /* guest can send gratuit. pkts */
+#define	VIRTIO_NET_F_CSUM	(1 <<  0) /* host handles partial cksum */
+#define	VIRTIO_NET_F_GUEST_CSUM	(1 <<  1) /* guest handles partial cksum */
+#define	VIRTIO_NET_F_MAC	(1 <<  5) /* host supplies MAC */
+#define	VIRTIO_NET_F_GSO_DEPREC	(1 <<  6) /* deprecated: host handles GSO */
+#define	VIRTIO_NET_F_GUEST_TSO4	(1 <<  7) /* guest can rcv TSOv4 */
+#define	VIRTIO_NET_F_GUEST_TSO6	(1 <<  8) /* guest can rcv TSOv6 */
+#define	VIRTIO_NET_F_GUEST_ECN	(1 <<  9) /* guest can rcv TSO with ECN */
+#define	VIRTIO_NET_F_GUEST_UFO	(1 << 10) /* guest can rcv UFO */
+#define	VIRTIO_NET_F_HOST_TSO4	(1 << 11) /* host can rcv TSOv4 */
+#define	VIRTIO_NET_F_HOST_TSO6	(1 << 12) /* host can rcv TSOv6 */
+#define	VIRTIO_NET_F_HOST_ECN	(1 << 13) /* host can rcv TSO with ECN */
+#define	VIRTIO_NET_F_HOST_UFO	(1 << 14) /* host can rcv UFO */
+#define	VIRTIO_NET_F_MRG_RXBUF	(1 << 15) /* host can merge RX buffers */
+#define	VIRTIO_NET_F_STATUS	(1 << 16) /* config status field available */
+#define	VIRTIO_NET_F_CTRL_VQ	(1 << 17) /* control channel available */
+#define	VIRTIO_NET_F_CTRL_RX	(1 << 18) /* control channel RX mode support */
+#define	VIRTIO_NET_F_CTRL_VLAN	(1 << 19) /* control channel VLAN filtering */
+#define	VIRTIO_NET_F_GUEST_ANNOUNCE \
+				(1 << 21) /* guest can send gratuitous pkts */
 
 #define VTNET_S_HOSTCAPS \
 	(VIRTIO_NET_F_MAC | VIRTIO_NET_F_MRG_RXBUF | VIRTIO_NET_F_STATUS | \
 	VIRTIO_F_NOTIFY_ON_EMPTY)
-
-// #define ETHER_IS_MULTICAST(addr) (*(addr) & 0x01) /* is address mcast/bcast? */
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpacked"
@@ -120,22 +119,23 @@ struct virtio_net_config {
 /*
  * Queue definitions.
  */
-#define VTNET_RXQ 0
-#define VTNET_TXQ 1
-// #define VTNET_CTLQ 2 /* NB: not yet supported */
-#define VTNET_MAXQ 3
+#define VTNET_RXQ	0
+#define VTNET_TXQ	1
+#define VTNET_CTLQ	2	/* NB: not yet supported */
+
+#define VTNET_MAXQ	3
 
 /*
  * Fixed network header size
  */
 struct virtio_net_rxhdr {
-	uint8_t vrh_flags;
-	uint8_t vrh_gso_type;
-	uint16_t vrh_hdr_len;
-	uint16_t vrh_gso_size;
-	uint16_t vrh_csum_start;
-	uint16_t vrh_csum_offset;
-	uint16_t vrh_bufs;
+	uint8_t		vrh_flags;
+	uint8_t		vrh_gso_type;
+	uint16_t	vrh_hdr_len;
+	uint16_t	vrh_gso_size;
+	uint16_t	vrh_csum_start;
+	uint16_t	vrh_csum_offset;
+	uint16_t	vrh_bufs;
 } __packed;
 
 #pragma clang diagnostic pop
@@ -156,18 +156,23 @@ struct pci_vtnet_softc {
 	struct vqueue_info vsc_queues[VTNET_MAXQ - 1];
 	pthread_mutex_t vsc_mtx;
 	struct vmnet_state *vms;
-	int vsc_rx_ready;
-	volatile int resetting;/* set and checked outside lock */
-	uint64_t vsc_features; /* negotiated features */
+
+	int		vsc_rx_ready;
+	volatile int	resetting;	/* set and checked outside lock */
+
+	uint64_t	vsc_features;	/* negotiated features */
+
 	struct virtio_net_config vsc_config;
-	pthread_mutex_t rx_mtx;
-	int rx_in_progress;
-	int rx_vhdrlen;
-	int rx_merge; /* merged rx bufs in use */
-	pthread_t tx_tid;
-	pthread_mutex_t tx_mtx;
-	pthread_cond_t tx_cond;
-	int tx_in_progress;
+
+	pthread_mutex_t	rx_mtx;
+	int		rx_in_progress;
+	int		rx_vhdrlen;
+	int		rx_merge;	/* merged rx bufs in use */
+
+	pthread_t 	tx_tid;
+	pthread_mutex_t	tx_mtx;
+	pthread_cond_t	tx_cond;
+	int		tx_in_progress;
 };
 
 static void pci_vtnet_reset(void *);
@@ -433,7 +438,7 @@ pci_vtnet_tap_tx(struct pci_vtnet_softc *sc, struct iovec *iov, int iovcnt,
 	 */
 	if (len < 60) {
 		iov[iovcnt].iov_base = pad;
-		iov[iovcnt].iov_len = (size_t) (60 - len);
+		iov[iovcnt].iov_len = (size_t)(60 - len);
 		iovcnt++;
 	}
 	vmn_write(sc->vms, iov, iovcnt);
@@ -454,16 +459,16 @@ rx_iov_trim(struct iovec *iov, int *niov, int tlen)
 	struct iovec *riov;
 
 	/* XXX short-cut: assume first segment is >= tlen */
-	assert(iov[0].iov_len >= ((size_t) tlen));
+	assert(iov[0].iov_len >= (size_t)tlen);
 
-	iov[0].iov_len -= ((size_t) tlen);
+	iov[0].iov_len -= (size_t)tlen;
 	if (iov[0].iov_len == 0) {
 		assert(*niov > 1);
 		*niov -= 1;
 		riov = &iov[1];
 	} else {
 		iov[0].iov_base = (void *)((uintptr_t)iov[0].iov_base +
-			((size_t) tlen));
+			(size_t)tlen);
 		riov = &iov[0];
 	}
 
@@ -556,7 +561,7 @@ pci_vtnet_tap_rx(struct pci_vtnet_softc *sc)
 		/*
 		 * Release this chain and handle more chains.
 		 */
-		vq_relchain(vq, idx, ((uint32_t) (len + sc->rx_vhdrlen)));
+		vq_relchain(vq, idx, (uint32_t)(len + sc->rx_vhdrlen));
 	} while (vq_has_descs(vq));
 
 	/* Interrupt if needed, including for NOTIFY_ON_EMPTY. */
@@ -604,7 +609,7 @@ pci_vtnet_proctx(struct pci_vtnet_softc *sc, struct vqueue_info *vq)
 	n = vq_getchain(vq, &idx, iov, VTNET_MAXSEGS, NULL);
 	assert(n >= 1 && n <= VTNET_MAXSEGS);
 	plen = 0;
-	tlen = (int) iov[0].iov_len;
+	tlen = (int)iov[0].iov_len;
 	for (i = 1; i < n; i++) {
 		plen += iov[i].iov_len;
 		tlen += iov[i].iov_len;
@@ -614,7 +619,7 @@ pci_vtnet_proctx(struct pci_vtnet_softc *sc, struct vqueue_info *vq)
 	pci_vtnet_tap_tx(sc, &iov[1], n - 1, plen);
 
 	/* chain is processed, release it and set tlen */
-	vq_relchain(vq, idx, ((uint32_t) tlen));
+	vq_relchain(vq, idx, (uint32_t)tlen);
 }
 
 static void

--- a/src/lib/pci_virtio_net_vpnkit.c
+++ b/src/lib/pci_virtio_net_vpnkit.c
@@ -111,33 +111,33 @@ struct vif_info {
 } __packed;
 #pragma clang diagnostic pop
 
+
 /*
  * Host capabilities.  Note that we only offer a few of these.
  */
-// #define VIRTIO_NET_F_CSUM (1 << 0) /* host handles partial cksum */
-// #define VIRTIO_NET_F_GUEST_CSUM (1 << 1) /* guest handles partial cksum */
-#define VIRTIO_NET_F_MAC (1 << 5) /* host supplies MAC */
-// #define VIRTIO_NET_F_GSO_DEPREC (1 << 6) /* deprecated: host handles GSO */
-// #define VIRTIO_NET_F_GUEST_TSO4 (1 << 7) /* guest can rcv TSOv4 */
-// #define VIRTIO_NET_F_GUEST_TSO6 (1 << 8) /* guest can rcv TSOv6 */
-// #define VIRTIO_NET_F_GUEST_ECN (1 << 9) /* guest can rcv TSO with ECN */
-// #define VIRTIO_NET_F_GUEST_UFO (1 << 10) /* guest can rcv UFO */
-// #define VIRTIO_NET_F_HOST_TSO4 (1 << 11) /* host can rcv TSOv4 */
-// #define VIRTIO_NET_F_HOST_TSO6 (1 << 12) /* host can rcv TSOv6 */
-// #define VIRTIO_NET_F_HOST_ECN (1 << 13) /* host can rcv TSO with ECN */
-// #define VIRTIO_NET_F_HOST_UFO (1 << 14) /* host can rcv UFO */
-#define VIRTIO_NET_F_MRG_RXBUF (1 << 15) /* host can merge RX buffers */
-#define VIRTIO_NET_F_STATUS (1 << 16) /* config status field available */
-// #define VIRTIO_NET_F_CTRL_VQ (1 << 17) /* control channel available */
-// #define VIRTIO_NET_F_CTRL_RX (1 << 18) /* control channel RX mode support */
-// #define VIRTIO_NET_F_CTRL_VLAN (1 << 19) /* control channel VLAN filtering */
-// #define VIRTIO_NET_F_GUEST_ANNOUNCE (1 << 21) /* guest can send gratuit. pkts */
+#define	VIRTIO_NET_F_CSUM	(1 <<  0) /* host handles partial cksum */
+#define	VIRTIO_NET_F_GUEST_CSUM	(1 <<  1) /* guest handles partial cksum */
+#define	VIRTIO_NET_F_MAC	(1 <<  5) /* host supplies MAC */
+#define	VIRTIO_NET_F_GSO_DEPREC	(1 <<  6) /* deprecated: host handles GSO */
+#define	VIRTIO_NET_F_GUEST_TSO4	(1 <<  7) /* guest can rcv TSOv4 */
+#define	VIRTIO_NET_F_GUEST_TSO6	(1 <<  8) /* guest can rcv TSOv6 */
+#define	VIRTIO_NET_F_GUEST_ECN	(1 <<  9) /* guest can rcv TSO with ECN */
+#define	VIRTIO_NET_F_GUEST_UFO	(1 << 10) /* guest can rcv UFO */
+#define	VIRTIO_NET_F_HOST_TSO4	(1 << 11) /* host can rcv TSOv4 */
+#define	VIRTIO_NET_F_HOST_TSO6	(1 << 12) /* host can rcv TSOv6 */
+#define	VIRTIO_NET_F_HOST_ECN	(1 << 13) /* host can rcv TSO with ECN */
+#define	VIRTIO_NET_F_HOST_UFO	(1 << 14) /* host can rcv UFO */
+#define	VIRTIO_NET_F_MRG_RXBUF	(1 << 15) /* host can merge RX buffers */
+#define	VIRTIO_NET_F_STATUS	(1 << 16) /* config status field available */
+#define	VIRTIO_NET_F_CTRL_VQ	(1 << 17) /* control channel available */
+#define	VIRTIO_NET_F_CTRL_RX	(1 << 18) /* control channel RX mode support */
+#define	VIRTIO_NET_F_CTRL_VLAN	(1 << 19) /* control channel VLAN filtering */
+#define	VIRTIO_NET_F_GUEST_ANNOUNCE \
+				(1 << 21) /* guest can send gratuitous pkts */
 
 #define VTNET_S_HOSTCAPS \
 	(VIRTIO_NET_F_MAC | VIRTIO_NET_F_MRG_RXBUF | VIRTIO_NET_F_STATUS | \
 	VIRTIO_F_NOTIFY_ON_EMPTY)
-
-// #define ETHER_IS_MULTICAST(addr) (*(addr) & 0x01) /* is address mcast/bcast? */
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpacked"
@@ -153,22 +153,23 @@ struct virtio_net_config {
 /*
  * Queue definitions.
  */
-#define VTNET_RXQ 0
-#define VTNET_TXQ 1
-// #define VTNET_CTLQ 2 /* NB: not yet supported */
-#define VTNET_MAXQ 3
+#define VTNET_RXQ	0
+#define VTNET_TXQ	1
+#define VTNET_CTLQ	2	/* NB: not yet supported */
+
+#define VTNET_MAXQ	3
 
 /*
  * Fixed network header size
  */
 struct virtio_net_rxhdr {
-	uint8_t vrh_flags;
-	uint8_t vrh_gso_type;
-	uint16_t vrh_hdr_len;
-	uint16_t vrh_gso_size;
-	uint16_t vrh_csum_start;
-	uint16_t vrh_csum_offset;
-	uint16_t vrh_bufs;
+	uint8_t		vrh_flags;
+	uint8_t		vrh_gso_type;
+	uint16_t	vrh_hdr_len;
+	uint16_t	vrh_gso_size;
+	uint16_t	vrh_csum_start;
+	uint16_t	vrh_csum_offset;
+	uint16_t	vrh_bufs;
 } __packed;
 
 #pragma clang diagnostic pop
@@ -189,18 +190,23 @@ struct pci_vtnet_softc {
 	struct vqueue_info vsc_queues[VTNET_MAXQ - 1];
 	pthread_mutex_t vsc_mtx;
 	struct vpnkit_state *state;
-	int vsc_rx_ready;
-	volatile int resetting;/* set and checked outside lock */
-	uint64_t vsc_features; /* negotiated features */
+
+	int		vsc_rx_ready;
+	volatile int	resetting;	/* set and checked outside lock */
+
+	uint64_t	vsc_features;	/* negotiated features */
+
 	struct virtio_net_config vsc_config;
-	pthread_mutex_t rx_mtx;
-	int rx_in_progress;
-	int rx_vhdrlen;
-	int rx_merge; /* merged rx bufs in use */
-	pthread_t tx_tid;
-	pthread_mutex_t tx_mtx;
-	pthread_cond_t tx_cond;
-	int tx_in_progress;
+
+	pthread_mutex_t	rx_mtx;
+	int		rx_in_progress;
+	int		rx_vhdrlen;
+	int		rx_merge;	/* merged rx bufs in use */
+
+	pthread_t 	tx_tid;
+	pthread_mutex_t	tx_mtx;
+	pthread_cond_t	tx_cond;
+	int		tx_in_progress;
 };
 
 static void pci_vtnet_reset(void *);
@@ -685,7 +691,7 @@ pci_vtnet_tap_tx(struct pci_vtnet_softc *sc, struct iovec *iov, int iovcnt,
 	 */
 	if (len < 60) {
 		iov[iovcnt].iov_base = pad;
-		iov[iovcnt].iov_len = (size_t) (60 - len);
+		iov[iovcnt].iov_len = (size_t)(60 - len);
 		iovcnt++;
 	}
 	vmn_write(sc->state, iov, iovcnt);
@@ -706,16 +712,16 @@ rx_iov_trim(struct iovec *iov, int *niov, int tlen)
 	struct iovec *riov;
 
 	/* XXX short-cut: assume first segment is >= tlen */
-	assert(iov[0].iov_len >= ((size_t) tlen));
+	assert(iov[0].iov_len >= (size_t)tlen);
 
-	iov[0].iov_len -= ((size_t) tlen);
+	iov[0].iov_len -= (size_t)tlen;
 	if (iov[0].iov_len == 0) {
 		assert(*niov > 1);
 		*niov -= 1;
 		riov = &iov[1];
 	} else {
 		iov[0].iov_base = (void *)((uintptr_t)iov[0].iov_base +
-			((size_t) tlen));
+			(size_t)tlen);
 		riov = &iov[0];
 	}
 
@@ -877,7 +883,7 @@ pci_vtnet_proctx(struct pci_vtnet_softc *sc, struct vqueue_info *vq)
 	n = vq_getchain(vq, &idx, iov, VTNET_MAXSEGS, NULL);
 	assert(n >= 1 && n <= VTNET_MAXSEGS);
 	plen = 0;
-	tlen = (int) iov[0].iov_len;
+	tlen = (int)iov[0].iov_len;
 	for (i = 1; i < n; i++) {
 		plen += iov[i].iov_len;
 		tlen += iov[i].iov_len;
@@ -887,7 +893,7 @@ pci_vtnet_proctx(struct pci_vtnet_softc *sc, struct vqueue_info *vq)
 	pci_vtnet_tap_tx(sc, &iov[1], n - 1, plen);
 
 	/* chain is processed, release it and set tlen */
-	vq_relchain(vq, idx, ((uint32_t) tlen));
+	vq_relchain(vq, idx, (uint32_t)tlen);
 }
 
 static void

--- a/src/lib/pci_virtio_net_vpnkit.c
+++ b/src/lib/pci_virtio_net_vpnkit.c
@@ -86,8 +86,6 @@
 /*
  * wire protocol
  */
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
 struct msg_init {
 	uint8_t magic[5]; /* VMN3T */
 	uint32_t version;
@@ -109,7 +107,6 @@ struct vif_info {
 	uint16_t max_packet_size;
 	uint8_t mac[6];
 } __packed;
-#pragma clang diagnostic pop
 
 
 /*
@@ -138,9 +135,6 @@ struct vif_info {
 #define VTNET_S_HOSTCAPS \
 	(VIRTIO_NET_F_MAC | VIRTIO_NET_F_MRG_RXBUF | VIRTIO_NET_F_STATUS | \
 	VIRTIO_F_NOTIFY_ON_EMPTY)
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
 
 /*
  * PCI config-space "registers"
@@ -171,8 +165,6 @@ struct virtio_net_rxhdr {
 	uint16_t	vrh_csum_offset;
 	uint16_t	vrh_bufs;
 } __packed;
-
-#pragma clang diagnostic pop
 
 /*
  * Debug printf

--- a/src/lib/pci_virtio_net_vpnkit.c
+++ b/src/lib/pci_virtio_net_vpnkit.c
@@ -180,8 +180,6 @@ struct virtio_net_rxhdr {
 static int pci_vtnet_debug;
 #define DPRINTF(params) if (pci_vtnet_debug) printf params
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 /*
  * Per-device softc
  */
@@ -231,8 +229,6 @@ struct vpnkit_state {
 	int fd;
 	struct vif_info vif;
 };
-
-#pragma clang diagnostic pop
 
 static int really_read(int fd, uint8_t *buffer, size_t total)
 {

--- a/src/lib/pci_virtio_rnd.c
+++ b/src/lib/pci_virtio_rnd.c
@@ -56,8 +56,6 @@ static int pci_vtrnd_debug;
 #define DPRINTF(params) if (pci_vtrnd_debug) printf params
 #define WPRINTF(params) printf params
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 /*
  * Per-device softc
  */
@@ -68,7 +66,6 @@ struct pci_vtrnd_softc {
 	uint64_t            vrsc_cfg;
 	int                 vrsc_fd;
 };
-#pragma clang diagnostic pop
 
 static void pci_vtrnd_reset(void *);
 static void pci_vtrnd_notify(void *, struct vqueue_info *);

--- a/src/lib/pci_virtio_rnd.c
+++ b/src/lib/pci_virtio_rnd.c
@@ -63,10 +63,10 @@ static int pci_vtrnd_debug;
  */
 struct pci_vtrnd_softc {
 	struct virtio_softc vrsc_vs;
-	struct vqueue_info vrsc_vq;
-	pthread_mutex_t vrsc_mtx;
-	uint64_t vrsc_cfg;
-	int vrsc_fd;
+	struct vqueue_info  vrsc_vq;
+	pthread_mutex_t     vrsc_mtx;
+	uint64_t            vrsc_cfg;
+	int                 vrsc_fd;
 };
 #pragma clang diagnostic pop
 
@@ -74,15 +74,15 @@ static void pci_vtrnd_reset(void *);
 static void pci_vtrnd_notify(void *, struct vqueue_info *);
 
 static struct virtio_consts vtrnd_vi_consts = {
-	"vtrnd", /* our name */
-	1, /* we support 1 virtqueue */
-	0, /* config reg size */
-	pci_vtrnd_reset, /* reset */
-	pci_vtrnd_notify, /* device-wide qnotify */
-	NULL, /* read virtio config */
-	NULL, /* write virtio config */
-	NULL, /* apply negotiated features */
-	0, /* our capabilities */
+	"vtrnd",		/* our name */
+	1,			/* we support 1 virtqueue */
+	0,			/* config reg size */
+	pci_vtrnd_reset,	/* reset */
+	pci_vtrnd_notify,	/* device-wide qnotify */
+	NULL,			/* read virtio config */
+	NULL,			/* write virtio config */
+	NULL,			/* apply negotiated features */
+	0,			/* our capabilities */
 };
 
 
@@ -126,7 +126,7 @@ pci_vtrnd_notify(void *vsc, struct vqueue_info *vq)
 		/*
 		 * Release this chain and handle more
 		 */
-		vq_relchain(vq, idx, ((uint32_t) len));
+		vq_relchain(vq, idx, (uint32_t)len);
 	}
 	vq_endchains(vq, 1);	/* Generate interrupt if appropriate. */
 }

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -132,9 +132,6 @@ static int pci_vtsock_debug = 0;
 /* Protocol logging */
 #define PPRINTF(params) do { if (0) { printf params;  fflush(stdout); } } while(0)
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
-
 /* XXX need to use rx and tx more consistently */
 
 struct vsock_addr {
@@ -340,7 +337,6 @@ struct pci_vtsock_softc {
 //#define REPLY_RING_FULL(sc) ((sc->reply_prod + 1) % VTSOCK_REPLYRINGSZ == sc->reply_cons)
 };
 
-#pragma clang diagnostic pop
 
 /* Protocol stuff */
 

--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -80,8 +80,6 @@
 	(VIRTIO_RING_F_INDIRECT_DESC) /* indirect descriptors */
 #endif
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
 /*
  * Config space "registers"
  */
@@ -121,8 +119,6 @@ struct virtio_sock_hdr {
 	uint32_t buf_alloc;
 	uint32_t fwd_cnt;
 } __packed;
-
-#pragma clang diagnostic pop
 
 /*
  * Debug printf

--- a/src/lib/smbiostbl.c
+++ b/src/lib/smbiostbl.c
@@ -39,9 +39,6 @@
 #include <xhyve/xhyve.h>
 #include <xhyve/smbiostbl.h>
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpacked"
-
 #define	GB			(1024ULL*1024*1024)
 
 #define SMBIOS_BASE		0xF1000
@@ -300,8 +297,6 @@ struct smbios_table_type32 {
 struct smbios_table_type127 {
 	struct smbios_structure	header;
 } __packed;
-
-#pragma clang diagnostic pop
 
 static struct smbios_table_type0 smbios_type0_template = {
 	{ SMBIOS_TYPE_BIOS, sizeof (struct smbios_table_type0), 0 },

--- a/src/lib/smbiostbl.c
+++ b/src/lib/smbiostbl.c
@@ -42,22 +42,22 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpacked"
 
-#define	GB (1024ULL*1024*1024)
+#define	GB			(1024ULL*1024*1024)
 
-#define SMBIOS_BASE 0xF1000
+#define SMBIOS_BASE		0xF1000
 
 /* BHYVE_ACPI_BASE - SMBIOS_BASE) */
-#define	SMBIOS_MAX_LENGTH (0xF2400 - 0xF1000)
+#define	SMBIOS_MAX_LENGTH	(0xF2400 - 0xF1000)
 
-#define	SMBIOS_TYPE_BIOS 0
-#define	SMBIOS_TYPE_SYSTEM 1
-#define	SMBIOS_TYPE_CHASSIS 3
-#define	SMBIOS_TYPE_PROCESSOR 4
-#define	SMBIOS_TYPE_MEMARRAY 16
-#define	SMBIOS_TYPE_MEMDEVICE 17
-#define	SMBIOS_TYPE_MEMARRAYMAP 19
-#define	SMBIOS_TYPE_BOOT 32
-#define	SMBIOS_TYPE_EOT 127
+#define	SMBIOS_TYPE_BIOS	0
+#define	SMBIOS_TYPE_SYSTEM	1
+#define	SMBIOS_TYPE_CHASSIS	3
+#define	SMBIOS_TYPE_PROCESSOR	4
+#define	SMBIOS_TYPE_MEMARRAY	16
+#define	SMBIOS_TYPE_MEMDEVICE	17
+#define	SMBIOS_TYPE_MEMARRAYMAP	19
+#define	SMBIOS_TYPE_BOOT	32
+#define	SMBIOS_TYPE_EOT		127
 
 struct smbios_structure {
 	uint8_t		type;
@@ -384,24 +384,24 @@ static struct smbios_table_type4 smbios_type4_template = {
 	1,		/* socket designation string */
 	SMBIOS_PRT_CENTRAL,
 	SMBIOS_PRF_OTHER,
-	2, /* manufacturer string */
-	0, /* cpuid */
-	3, /* version string */
-	0, /* voltage */
-	0, /* external clock frequency in mhz (0=unknown) */
-	0, /* maximum frequency in mhz (0=unknown) */
-	0, /* current frequency in mhz (0=unknown) */
+	2,		/* manufacturer string */
+	0,		/* cpuid */
+	3,		/* version string */
+	0,		/* voltage */
+	0,		/* external clock frequency in mhz (0=unknown) */
+	0,		/* maximum frequency in mhz (0=unknown) */
+	0,		/* current frequency in mhz (0=unknown) */
 	SMBIOS_PRS_PRESENT | SMBIOS_PRS_ENABLED,
 	SMBIOS_PRU_NONE,
-	(uint16_t) (-1), /* l1 cache handle */
-	(uint16_t) (-1), /* l2 cache handle */
-	(uint16_t) (-1), /* l3 cache handle */
-	4, /* serial number string */
-	5, /* asset tag string */
-	6, /* part number string */
-	0, /* cores per socket (0=unknown) */
-	0, /* enabled cores per socket (0=unknown) */
-	0, /* threads per socket (0=unknown) */
+	(uint16_t)-1,	/* l1 cache handle */
+	(uint16_t)-1,	/* l2 cache handle */
+	(uint16_t)-1,	/* l3 cache handle */
+	4,		/* serial number string */
+	5,		/* asset tag string */
+	6,		/* part number string */
+	0,		/* cores per socket (0=unknown) */
+	0,		/* enabled cores per socket (0=unknown) */
+	0,		/* threads per socket (0=unknown) */
 	SMBIOS_PFL_64B,
 	SMBIOS_PRF_OTHER
 };
@@ -425,10 +425,10 @@ static struct smbios_table_type16 smbios_type16_template = {
 	SMBIOS_MAL_SYSMB,
 	SMBIOS_MAU_SYSTEM,
 	SMBIOS_MAE_NONE,
-	0x80000000, /* max mem capacity in kb (0x80000000=use extended) */
-	(uint16_t) (-1), /* handle of error (if any) */
-	0, /* number of slots or sockets (TBD) */
-	0 /* extended maximum memory capacity in bytes (TBD) */
+	0x80000000,	/* max mem capacity in kb (0x80000000=use extended) */
+	(uint16_t)-1,	/* handle of error (if any) */
+	0,		/* number of slots or sockets (TBD) */
+	0		/* extended maximum memory capacity in bytes (TBD) */
 };
 
 static int smbios_type16_initializer(struct smbios_structure *template_entry,
@@ -437,28 +437,28 @@ static int smbios_type16_initializer(struct smbios_structure *template_entry,
 
 static struct smbios_table_type17 smbios_type17_template = {
 	{ SMBIOS_TYPE_MEMDEVICE, sizeof (struct smbios_table_type17),  0 },
-	(uint16_t) (-1), /* handle of physical memory array */
-	(uint16_t) (-1), /* handle of memory error data */
-	64, /* total width in bits including ecc */
-	64, /* data width in bits */
-	0x7fff, /* size in bytes (0x7fff=use extended)*/
+	(uint16_t)-1,	/* handle of physical memory array */
+	(uint16_t)-1,	/* handle of memory error data */
+	64,		/* total width in bits including ecc */
+	64,		/* data width in bits */
+	0x7fff,		/* size in bytes (0x7fff=use extended)*/
 	SMBIOS_MDFF_UNKNOWN,
-	0, /* set (0x00=none, 0xff=unknown) */
-	1, /* device locator string */
-	2, /* physical bank locator string */
+	0,		/* set (0x00=none, 0xff=unknown) */
+	1,		/* device locator string */
+	2,		/* physical bank locator string */
 	SMBIOS_MDT_UNKNOWN,
 	SMBIOS_MDF_UNKNOWN,
-	0, /* maximum memory speed in mhz (0=unknown) */
-	3, /* manufacturer string */
-	4, /* serial number string */
-	5, /* asset tag string */
-	6, /* part number string */
-	0, /* attributes (0=unknown rank information) */
-	0, /* extended size in mb (TBD) */
-	0, /* current speed in mhz (0=unknown) */
-	0, /* minimum voltage in mv (0=unknown) */
-	0, /* maximum voltage in mv (0=unknown) */
-	0 /* configured voltage in mv (0=unknown) */
+	0,		/* maximum memory speed in mhz (0=unknown) */
+	3,		/* manufacturer string */
+	4,		/* serial number string */
+	5,		/* asset tag string */
+	6,		/* part number string */
+	0,		/* attributes (0=unknown rank information) */
+	0,		/* extended size in mb (TBD) */
+	0,		/* current speed in mhz (0=unknown) */
+	0,		/* minimum voltage in mv (0=unknown) */
+	0,		/* maximum voltage in mv (0=unknown) */
+	0		/* configured voltage in mv (0=unknown) */
 };
 
 static const char *smbios_type17_strings[] = {
@@ -477,12 +477,12 @@ static int smbios_type17_initializer(struct smbios_structure *template_entry,
 
 static struct smbios_table_type19 smbios_type19_template = {
 	{ SMBIOS_TYPE_MEMARRAYMAP, sizeof (struct smbios_table_type19),  0 },
-	0xffffffff, /* starting phys addr in kb (0xffffffff=use ext) */
-	0xffffffff, /* ending phys addr in kb (0xffffffff=use ext) */
-	(uint16_t) (-1), /* physical memory array handle */
-	1, /* number of devices that form a row */
-	0, /* extended starting phys addr in bytes (TDB) */
-	0 /* extended ending phys addr in bytes (TDB) */
+	0xffffffff,	/* starting phys addr in kb (0xffffffff=use ext) */
+	0xffffffff,	/* ending phys addr in kb (0xffffffff=use ext) */
+	(uint16_t)-1,	/* physical memory array handle */
+	1,		/* number of devices that form a row */
+	0,		/* extended starting phys addr in bytes (TDB) */
+	0		/* extended ending phys addr in bytes (TDB) */
 };
 
 static int smbios_type19_initializer(struct smbios_structure *template_entry,
@@ -556,7 +556,7 @@ smbios_generic_initializer(struct smbios_structure *template_entry,
 			int len;
 
 			string = template_strings[i];
-			len = (int) (strlen(string) + 1);
+			len = (int)(strlen(string) + 1);
 			memcpy(curaddr, string, len);
 			curaddr += len;
 		}
@@ -609,8 +609,8 @@ smbios_type1_initializer(struct smbios_structure *template_entry,
 			return (-1);
 
 		MD5Init(&mdctx);
-		MD5Update(&mdctx, vmname, ((unsigned) strlen(vmname)));
-		MD5Update(&mdctx, hostname, ((unsigned) sizeof(hostname)));
+		MD5Update(&mdctx, vmname, (unsigned)strlen(vmname));
+		MD5Update(&mdctx, hostname, (unsigned)sizeof(hostname));
 		MD5Final(digest, &mdctx);
 
 		/*
@@ -652,7 +652,7 @@ smbios_type4_initializer(struct smbios_structure *template_entry,
 		*endaddr += len - 1;
 		*(*endaddr) = '\0';
 		(*endaddr)++;
-		type4->socket = (uint8_t) (nstrings + 1);
+		type4->socket = (uint8_t)(nstrings + 1);
 		curaddr = *endaddr;
 	}
 
@@ -687,7 +687,7 @@ smbios_type17_initializer(struct smbios_structure *template_entry,
 	    curaddr, endaddr, n, size);
 	type17 = (struct smbios_table_type17 *)curaddr;
 	type17->arrayhand = type16_handle;
-	type17->xsize = (uint32_t) guest_lomem;
+	type17->xsize = (uint32_t)guest_lomem;
 
 	if (guest_himem > 0) {
 		curaddr = *endaddr;
@@ -695,7 +695,7 @@ smbios_type17_initializer(struct smbios_structure *template_entry,
 		    curaddr, endaddr, n, size);
 		type17 = (struct smbios_table_type17 *)curaddr;
 		type17->arrayhand = type16_handle;
-		type17->xsize = (uint32_t) guest_himem;
+		type17->xsize = (uint32_t)guest_himem;
 	}
 
 	return (0);
@@ -772,12 +772,12 @@ smbios_ep_finalizer(struct smbios_entry_point *smbios_ep, uint16_t len,
 int
 smbios_build(void)
 {
-	struct smbios_entry_point *smbios_ep;
-	uint16_t n;
-	uint16_t maxssize;
-	char *curaddr, *startaddr, *ststartaddr;
-	int i;
-	int err;
+	struct smbios_entry_point	*smbios_ep;
+	uint16_t			n;
+	uint16_t			maxssize;
+	char				*curaddr, *startaddr, *ststartaddr;
+	int				i;
+	int				err;
 
 	guest_lomem = xh_vm_get_lowmem_size();
 	guest_himem = xh_vm_get_highmem_size();
@@ -800,10 +800,10 @@ smbios_build(void)
 	maxssize = 0;
 	for (i = 0; smbios_template[i].entry != NULL; i++) {
 		struct smbios_structure	*entry;
-		const char **strings;
-		initializer_func_t initializer;
-		char *endaddr;
-		uint16_t size;
+		const char		**strings;
+		initializer_func_t      initializer;
+		char			*endaddr;
+		uint16_t		size;
 
 		entry = smbios_template[i].entry;
 		strings = smbios_template[i].strings;

--- a/src/lib/uart_emul.c
+++ b/src/lib/uart_emul.c
@@ -69,8 +69,6 @@
 static bool uart_stdio;		/* stdio in use for i/o */
 static struct termios tio_stdio_orig;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 static struct {
 	int	baseaddr;
 	int	irq;
@@ -129,7 +127,6 @@ struct uart_softc {
 	uart_intr_func_t intr_assert;
 	uart_intr_func_t intr_deassert;
 };
-#pragma clang diagnostic pop
 
 static void uart_drain(int fd, enum ev_type ev, void *arg);
 

--- a/src/lib/virtio.c
+++ b/src/lib/virtio.c
@@ -466,8 +466,6 @@ vq_endchains(struct vqueue_info *vq, int used_all_avail)
 		vq_interrupt(vs, vq);
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 /* Note: these are in sorted order to make for a fast search */
 static struct config_reg {
 	uint16_t	cr_offset;	/* register offset */
@@ -486,7 +484,6 @@ static struct config_reg {
 	{ VTCFG_R_CFGVEC,	2, 0, "CFGVEC" },
 	{ VTCFG_R_QVEC,		2, 0, "QVEC" },
 };
-#pragma clang diagnostic pop
 
 static inline struct config_reg *
 vi_find_cr(int offset) {

--- a/src/lib/vmm/io/vatpic.c
+++ b/src/lib/vmm/io/vatpic.c
@@ -47,8 +47,6 @@ enum irqstate {
 	IRQSTATE_PULSE
 };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct atpic {
 	bool ready;
 	int icw_num;
@@ -73,7 +71,6 @@ struct vatpic {
 	struct atpic atpic[2];
 	uint8_t elc[2];
 };
-#pragma clang diagnostic pop
 
 #define	VATPIC_CTR0(vatpic, fmt)					\
 	VM_CTR0((vatpic)->vm, fmt)

--- a/src/lib/vmm/io/vatpit.c
+++ b/src/lib/vmm/io/vatpit.c
@@ -60,8 +60,6 @@
 #define	PIT_8254_FREQ		1193182
 #define	TIMER_DIV(freq, hz)	(((freq) + (hz) / 2) / (hz))
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vatpit_callout_arg {
 	struct vatpit *vatpit;
 	int channel_num;
@@ -89,7 +87,6 @@ struct vatpit {
 	sbintime_t freq_sbt;
 	struct channel channel[3];
 };
-#pragma clang diagnostic pop
 
 static void pit_timer_start_cntr0(struct vatpit *vatpit);
 

--- a/src/lib/vmm/io/vhpet.c
+++ b/src/lib/vmm/io/vhpet.c
@@ -55,8 +55,6 @@
 #define	VHPET_NUM_TIMERS	8
 CTASSERT(VHPET_NUM_TIMERS >= 3 && VHPET_NUM_TIMERS <= 32);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vhpet_callout_arg {
 	struct vhpet *vhpet;
 	int timer_num;
@@ -80,7 +78,6 @@ struct vhpet {
 		struct vhpet_callout_arg arg;
 	} timer[VHPET_NUM_TIMERS];
 };
-#pragma clang diagnostic pop
 
 #define	VHPET_LOCK(vhp) pthread_mutex_lock(&((vhp)->mtx))
 #define	VHPET_UNLOCK(vhp) pthread_mutex_unlock(&((vhp)->mtx))

--- a/src/lib/vmm/io/vioapic.c
+++ b/src/lib/vmm/io/vioapic.c
@@ -44,8 +44,6 @@
 #define	REDIR_ENTRIES	24
 #define	RTBL_RO_BITS	((uint64_t)(IOART_REM_IRR | IOART_DELIVS))
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vioapic {
 	struct vm *vm;
 	pthread_mutex_t lock;
@@ -56,7 +54,6 @@ struct vioapic {
 		int acnt; /* sum of pin asserts (+1) and deasserts (-1) */
 	} rtbl[REDIR_ENTRIES];
 };
-#pragma clang diagnostic pop
 
 #define VIOAPIC_LOCK_INIT(v) xpthread_mutex_init(&(v)->lock);
 #define VIOAPIC_LOCK(v) xpthread_mutex_lock(&(v)->lock)

--- a/src/lib/vmm/io/vpmtmr.c
+++ b/src/lib/vmm/io/vpmtmr.c
@@ -42,14 +42,11 @@
 
 #define PMTMR_FREQ	3579545  /* 3.579545MHz */
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vpmtmr {
 	sbintime_t	freq_sbt;
 	sbintime_t	baseuptime;
 	uint32_t	baseval;
 };
-#pragma clang diagnostic pop
 
 struct vpmtmr *
 vpmtmr_init(UNUSED struct vm *vm)

--- a/src/lib/vmm/io/vrtc.c
+++ b/src/lib/vmm/io/vrtc.c
@@ -79,8 +79,6 @@ struct rtcdev {
 CTASSERT(sizeof(struct rtcdev) == 128);
 CTASSERT(offsetof(struct rtcdev, century) == RTC_CENTURY);
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 struct vrtc {
 	struct vm *vm;
 	pthread_mutex_t mtx;
@@ -101,7 +99,6 @@ struct clocktime {
 	int	dow; /* day of week (0 - 6; 0 = Sunday) */
 	long nsec; /* nano seconds */
 };
-#pragma clang diagnostic pop
 
 #define	VRTC_LOCK(vrtc) pthread_mutex_lock(&((vrtc)->mtx))
 #define	VRTC_UNLOCK(vrtc) pthread_mutex_unlock(&((vrtc)->mtx))

--- a/src/lib/vmm/vmm.c
+++ b/src/lib/vmm/vmm.c
@@ -59,8 +59,6 @@
 
 struct vlapic;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 /*
  * Initialization:
  * (a) allocated when vcpu is created
@@ -133,7 +131,6 @@ struct vm {
 	pthread_mutex_t hv_pause_mtx;
 	pthread_cond_t hv_pause_cnd;
 };
-#pragma clang diagnostic pop
 
 static int vmm_initialized;
 

--- a/src/lib/vmm/vmm_api.c
+++ b/src/lib/vmm/vmm_api.c
@@ -482,8 +482,6 @@ xh_vm_inject_nmi(int vcpu)
 	return (vm_inject_nmi(vm, vcpu));
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpadded"
 static struct {
 	const char *name;
 	int type;
@@ -493,7 +491,6 @@ static struct {
 	{ "pause_exit", VM_CAP_PAUSE_EXIT },
 	{ NULL, 0 }
 };
-#pragma clang diagnostic pop
 
 int
 xh_vm_capability_name2type(const char *capname)


### PR DESCRIPTION
xhyve/hyperkit was derived from bhyve and shares more common code with it than there are differences. This is a first pass at trying to reduce the difference and mostly does two things:

- clean up casts introduced in xhyve. While the casts are necessary to compile with clang, xhyve used a lot of unnecessary parentheses and whitespaces. Cleaning them up increases the chance of upstreaming them to bhyve.
- add `-Wno-padded` to `CFLAGS` and remove pragmas from the source code
- mark commented out FreeBSD code with `#ifdef __FreeBSD__`
- whitespace cleanups. Bring hyperkit code more inline with bhyve formatting

/cc @ijc25 @avsm @luigirizzo 