### PR TITLE
Partial support for raw devices

### DIFF
--- a/hyperkit.1
+++ b/hyperkit.1
@@ -331,9 +331,9 @@ hyperkit -s 0,hostbridge -s 1,lpc -s 2:0,virtio-net,tap0 \\
   -A -H -P -m 24G -f fbsd,userboot.so,bootvolume.img,"" \\
 .Ed
 .Pp
-Run an 8GB quad-CPU virtual machine with 8 AHCI SATA disks, an AHCI ATAPI
-CD-ROM, a single virtio network port, an AMD hostbridge, and the console
-port connected to an
+Run an 8GB quad-CPU virtual machine with 8 AHCI SATA disks, a raw AHCI SATA volume,
+an AHCI ATAPI CD-ROM, a single virtio network port, an AMD hostbridge,
+and the console port connected to an
 .Xr nmdm 4
 null-modem device.
 .Bd -literal -offset indent
@@ -347,6 +347,7 @@ hyperkit -c 4 \\
   -s 1:5,ahci-hd,/images/disk.6 \\
   -s 1:6,ahci-hd,/images/disk.7 \\
   -s 1:7,ahci-hd,/images/disk.8 \\
+  -s 1:8,ahci-hd,/dev/rdisk2 \\
   -s 2,ahci-cd,/images/install.iso \\
   -s 3,virtio-net,tap0 \\
   -l com1,/dev/nmdm0A \\

--- a/test/test_linux.exp
+++ b/test/test_linux.exp
@@ -4,7 +4,11 @@ set KERNEL "./vmlinuz"
 set INITRD "./initrd.gz"
 set CMDLINE "earlyprintk=serial console=ttyS0"
 
-spawn ../build/com.docker.hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -f kexec,$KERNEL,$INITRD,$CMDLINE
+exec hdiutil create -megabytes 20 -fs "MS-DOS" disk
+set DISK [exec hdiutil attach -nomount -noverify -noautofsck disk.dmg | head -n1 | cut -f1 -d " "]
+set RDISK [string map { disk rdisk } $DISK]
+
+spawn ../build/com.docker.hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,$RDISK -f kexec,$KERNEL,$INITRD,$CMDLINE
 set pid [exp_pid]
 set timeout 20
 
@@ -12,9 +16,18 @@ expect {
   timeout {puts "FAIL boot"; exec kill -9 $pid; exit 1}
   "\r\ntc@box:~$ "
 }
+send "sudo mount /dev/sda1 /mnt/sda1\r\n"
+send "sudo touch /mnt/sda1/test\r\n"
+send "sudo umount /mnt/sda1\r\n"
 send "sudo halt\r\n";
 expect {
   timeout {puts "FAIL shutdown"; exec kill -9 $pid; exit 1}
   "reboot: System halted"
 }
+
+exec hdiutil mount -mountpoint ./test-vol ${DISK}s1
+exec cat ./test-vol/test
+exec hdiutil detach $DISK
+exec rm disk.dmg
+
 puts "\n\nPASS"


### PR DESCRIPTION
I haven't checked, whether all kinds of volumes work, but virtual disk images do, which allows you to use sparse volumes now with xhyve.

Example:

```
hdiutil create -megabytes 20 -fs "MS-DOS" disk
hdiutil attach disk.dmg // Get disk number
xhyve ... -s 4:0,ahci-hd,/dev/rdiskN ...
```

Ported from https://github.com/mist64/xhyve/pull/80