### PR TITLE
Dump VM state on VMEXIT_ABORT

### DIFF
--- a/src/hyperkit.c
+++ b/src/hyperkit.c
@@ -633,6 +633,7 @@ vcpu_loop(int vcpu, uint64_t startrip)
 		case VMEXIT_CONTINUE:
 			break;
 		case VMEXIT_ABORT:
+			xh_vm_vcpu_dump(vcpu);
 			abort();
 		default:
 			exit(1);

--- a/src/include/xhyve/vmm/vmm.h
+++ b/src/include/xhyve/vmm/vmm.h
@@ -64,6 +64,7 @@ typedef int (*vmm_init_func_t)(void);
 typedef int (*vmm_cleanup_func_t)(void);
 typedef void *(*vmi_vm_init_func_t)(struct vm *vm);
 typedef int (*vmi_vcpu_init_func_t)(void *vmi, int vcpu);
+typedef void (*vmi_vcpu_dump_func_t)(void *vmi, int vcpu);
 typedef int (*vmi_run_func_t)(void *vmi, int vcpu, register_t rip,
 	void *rendezvous_cookie, void *suspend_cookie);
 typedef void (*vmi_vm_cleanup_func_t)(void *vmi);
@@ -87,6 +88,7 @@ struct vmm_ops {
 	vmm_cleanup_func_t cleanup;
 	vmi_vm_init_func_t vm_init; /* vm-specific initialization */
 	vmi_vcpu_init_func_t vcpu_init;
+	vmi_vcpu_dump_func_t vcpu_dump;
 	vmi_run_func_t vmrun;
 	vmi_vm_cleanup_func_t vm_cleanup;
 	vmi_vcpu_cleanup_func_t vcpu_cleanup;
@@ -145,6 +147,7 @@ int vm_activate_cpu(struct vm *vm, int vcpu);
 struct vm_exit *vm_exitinfo(struct vm *vm, int vcpuid);
 void vm_exit_suspended(struct vm *vm, int vcpuid, uint64_t rip);
 void vm_exit_rendezvous(struct vm *vm, int vcpuid, uint64_t rip);
+void vm_vcpu_dump(struct vm *vm, int vcpuid);
 
 /*
  * Rendezvous all vcpus specified in 'dest' and execute 'func(arg)'.

--- a/src/include/xhyve/vmm/vmm_api.h
+++ b/src/include/xhyve/vmm/vmm_api.h
@@ -112,3 +112,4 @@ int xh_vm_restart_instruction(int vcpu);
 int xh_vm_emulate_instruction(int vcpu, uint64_t gpa, struct vie *vie,
 	struct vm_guest_paging *paging, mem_region_read_t memread,
 	mem_region_write_t memwrite, void *memarg);
+void xh_vm_vcpu_dump(int vcpu);

--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -2230,6 +2230,12 @@ vmx_vm_cleanup(void *arg)
 }
 
 static void
+vmx_vcpu_dump(void *arg UNUSED, int vcpu)
+{
+	hvdump(vcpu);
+}
+
+static void
 vmx_vcpu_cleanup(void *arg, int vcpuid) {
 	if (arg || vcpuid) xhyve_abort("vmx_vcpu_cleanup\n");
 }
@@ -2746,6 +2752,7 @@ struct vmm_ops vmm_ops_intel = {
 	vmx_cleanup,
 	vmx_vm_init,
 	vmx_vcpu_init,
+	vmx_vcpu_dump,
 	vmx_run,
 	vmx_vm_cleanup,
 	vmx_vcpu_cleanup,

--- a/src/lib/vmm/vmm.c
+++ b/src/lib/vmm/vmm.c
@@ -146,6 +146,8 @@ static struct vmm_ops *ops;
 	(*ops->vcpu_init)(vmi, vcpu)
 #define	VMRUN(vmi, vcpu, rip, rptr, sptr) \
 	(*ops->vmrun)(vmi, vcpu, rip, rptr, sptr)
+#define VCPU_DUMP(vmi, vcpu) \
+	(*ops->vcpu_dump)(vmi, vcpu)
 #define	VM_CLEANUP(vmi) \
 	(*ops->vm_cleanup)(vmi)
 #define	VCPU_CLEANUP(vmi, vcpu) \
@@ -1119,6 +1121,12 @@ vm_exit_rendezvous(struct vm *vm, int vcpuid, uint64_t rip)
 	vmexit->inst_length = 0;
 	vmexit->exitcode = VM_EXITCODE_RENDEZVOUS;
 	vmm_stat_incr(vm, vcpuid, VMEXIT_RENDEZVOUS, 1);
+}
+
+void
+vm_vcpu_dump(struct vm *vm, int vcpuid)
+{
+	VCPU_DUMP(vm->cookie, vcpuid);
 }
 
 void pittest(struct vm *thevm);

--- a/src/lib/vmm/vmm_api.c
+++ b/src/lib/vmm/vmm_api.c
@@ -831,3 +831,9 @@ xh_vm_emulate_instruction(int vcpu, uint64_t gpa, struct vie *vie,
 
 	return (error);
 }
+
+void
+xh_vm_vcpu_dump(int vcpu)
+{
+	vm_vcpu_dump(vm, vcpu);
+}


### PR DESCRIPTION
Otherwise if we take a trap for e.g. VM_EXITCODE_VMX then we have very little
to go on (basically only RIP and exit_reason + qualification).

Plumb the existing hvdump function (which dumps a lot of useful VMCS state,
including guest register state) up through the various API layers and have the
top-level call it for any VMEXIT_ABORT.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

/cc @rneugeba you might have opinions on the API layering and how to expose things?

Tested by adding an artificial VMEXIT_ABORT to `vcpu_loop` after 100 exits since I don't currently have an easy way to force such an exit.