### PR TITLE
Add support for qcow delete/discard/TRIM

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,26 +31,26 @@ If you are using Hyperkit directly then please report issues against this reposi
 The resulting binary will be in `build/com.docker.hyperkit`
 
 To enable qcow support in the block backend an OCaml [OPAM](https://opam.ocaml.org) development
-environment is required with the qcow-format module available. A
+environment is required with the qcow module available. A
 suitable environment can be setup by installing `opam` and `libev`
 via `brew` and using `opam` to install the appropriate libraries:
 
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow-format conf-libev
+    $ opam install uri qcow conf-libev
 
 Notes:
 
 - `opam config env` must be evaluated each time prior to building
   hyperkit so the build will find the ocaml environment.
-- Any previous pin of `mirage-block-unix` or `qcow-format`
+- Any previous pin of `mirage-block-unix` or `qcow`
   should be removed with the commands:
   
   ```sh
   $ opam update
   $ opam pin remove mirage-block-unix
-  $ opam pin remove qcow-format
+  $ opam pin remove qcow
   ```
 
 ## Tracing

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow-format ocamlfind conf-libev
+    - opam install --yes uri qcow ocamlfind conf-libev
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -232,8 +232,7 @@ block_delete(struct blockif_ctxt *bc, off_t offset, off_t len)
 			errno = EOPNOTSUPP;
 #ifdef HAVE_OCAML_QCOW
 	} else if (bc->bc_mbh >= 0) {
-		/* Not currently implemented */
-		errno = EOPNOTSUPP;
+		ret = mirage_block_delete(bc->bc_mbh, offset, len);
 #endif
 	} else
 		abort();

--- a/src/lib/dtrace.d
+++ b/src/lib/dtrace.d
@@ -9,4 +9,6 @@ provider hyperkit {
 	probe block__preadv__done(off_t, ssize_t);
 	probe block__pwritev(off_t, size_t);
 	probe block__pwritev__done(off_t, ssize_t);
+	probe block__delete(off_t, off_t);
+	probe block__delete__done(off_t, off_t);
 };

--- a/src/lib/mirage_block_c.c
+++ b/src/lib/mirage_block_c.c
@@ -217,6 +217,32 @@ mirage_block_pwritev(mirage_block_handle h, const struct iovec *iov, int iovcnt,
 }
 
 static void
+ocaml_mirage_block_delete(int handle, off_t offset, ssize_t len, int *err) {
+	CAMLparam0();
+	CAMLlocal4(ocaml_handle, result, ocaml_offset, ocaml_len);
+	ocaml_handle = Val_int(handle);
+	ocaml_offset = caml_copy_int64(offset);
+	ocaml_len = caml_copy_int64(len);
+	OCAML_NAMED_FUNCTION("mirage_block_delete")
+	result = caml_callback3_exn(*fn, ocaml_handle, ocaml_offset, ocaml_len);
+	*err = 0;
+	if (Is_exception_result(result)){
+		errno = EINVAL;
+		*err = 1;
+	}
+	CAMLreturn0;
+}
+
+int
+mirage_block_delete(mirage_block_handle handle, off_t offset, ssize_t len) {
+	int err = 1;
+	caml_acquire_runtime_system();
+	ocaml_mirage_block_delete(handle, offset, len, &err);
+	caml_release_runtime_system();
+	return err;
+}
+
+static void
 ocaml_mirage_block_flush(int handle, int *err) {
 	CAMLparam0();
 	CAMLlocal2(ocaml_handle, result);

--- a/src/lib/mirage_block_c.c
+++ b/src/lib/mirage_block_c.c
@@ -46,12 +46,13 @@ if (fn == NULL) { \
 	acquiring the runtime lock. */
 
 static void
-ocaml_mirage_block_open(const char *config, int *out, int *err) {
+ocaml_mirage_block_open(const char *config, const char *options, int *out, int *err) {
 	CAMLparam0();
-	CAMLlocal2(ocaml_config, handle);
+	CAMLlocal3(ocaml_config, ocaml_options, handle);
 	ocaml_config = caml_copy_string(config);
+	ocaml_options = caml_copy_string(options);
 	OCAML_NAMED_FUNCTION("mirage_block_open")
-	handle = caml_callback_exn(*fn, ocaml_config);
+	handle = caml_callback2_exn(*fn, ocaml_config, ocaml_options);
 	if (Is_exception_result(handle)){
 		*err = 1;
 	} else {
@@ -62,11 +63,11 @@ ocaml_mirage_block_open(const char *config, int *out, int *err) {
 }
 
 mirage_block_handle
-mirage_block_open(const char *config) {
+mirage_block_open(const char *config, const char *options) {
 	int result;
 	int err = 1;
 	caml_acquire_runtime_system();
-	ocaml_mirage_block_open(config, &result, &err);
+	ocaml_mirage_block_open(config, options, &result, &err);
 	caml_release_runtime_system();
 	if (err){
 		errno = EINVAL;

--- a/src/lib/mirage_block_c.h
+++ b/src/lib/mirage_block_c.h
@@ -55,6 +55,10 @@ extern ssize_t
 mirage_block_pwritev(mirage_block_handle h,
 	const struct iovec *iov, int iovcnt, off_t offset);
 
+/* TRIM/DELETE/DISCARD the range of sectors */
+extern int
+mirage_block_delete(mirage_block_handle h, off_t offset, ssize_t len);
+
 /* Flush any outstanding I/O */
 extern
 int mirage_block_flush(mirage_block_handle h);

--- a/src/lib/mirage_block_c.h
+++ b/src/lib/mirage_block_c.h
@@ -33,7 +33,7 @@ typedef int mirage_block_handle;
 
 /* Open a mirage block device with the given string configuration. */
 extern mirage_block_handle
-mirage_block_open(const char *config);
+mirage_block_open(const char *config, const char *options);
 
 struct mirage_block_stat {
 	int candelete;      /* 1 if the device supports TRIM/DELETE/DISCARD */

--- a/src/lib/mirage_block_c.h
+++ b/src/lib/mirage_block_c.h
@@ -35,9 +35,13 @@ typedef int mirage_block_handle;
 extern mirage_block_handle
 mirage_block_open(const char *config);
 
+struct mirage_block_stat {
+	int candelete;      /* 1 if the device supports TRIM/DELETE/DISCARD */
+};
+
 /* Query a mirage block device. */
 extern int
-mirage_block_stat(mirage_block_handle h, struct stat *buf);
+mirage_block_stat(mirage_block_handle h, struct stat *stat, struct mirage_block_stat *buf);
 
 /* Read data from a mirage block device. Note the offset must be sector-aligned
    and the memory buffers must also be sector-aligned. */

--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -68,7 +68,7 @@ module Protocol = struct
   module Response = struct
     type ok =
       | Connect of int
-      | Get_info of bool * int * int64
+      | Get_info of bool * int * int64 * bool
       | Disconnect
       | Read of int
       | Write of int
@@ -160,11 +160,11 @@ module C = struct
         Printf.fprintf stderr "mirage_block_open %s: %s\n%!" config m;
         exit 1
 
-  let mirage_block_stat (h: int) : (bool * int * int64) =
+  let mirage_block_stat (h: int) : (bool * int * int64 * bool) =
     Printf.fprintf stdout "mirage_block_stat\n%!";
     match ok_exn (Protocol.rpc (Protocol.Request.Get_info h)) with
-      | Protocol.Response.Get_info (read_write, sector_size, size_sectors) ->
-        read_write, sector_size, size_sectors
+      | Protocol.Response.Get_info (read_write, sector_size, size_sectors, candelete) ->
+        read_write, sector_size, size_sectors, candelete
       | _ ->
         Printf.fprintf stderr "protocol error: unexpected response to stat\n%!";
         exit 1
@@ -270,7 +270,8 @@ let process_one t =
       let open Lwt in
       B.get_info t.Handle.block
       >>= fun info ->
-      return (`Ok (Response.Get_info (info.B.read_write, info.B.sector_size, info.B.size_sectors)))
+      let candelete = false in
+      return (`Ok (Response.Get_info (info.B.read_write, info.B.sector_size, info.B.size_sectors, candelete)))
     | Request.Disconnect h ->
       let t = Handle.find_or_quit h in
       let open Lwt in


### PR DESCRIPTION
This PR adds support for `delete` (aka `discard` or `TRIM`) via the Mirage Qcow library.

The capability `candelete` (used to set `ATA_SUPPORT_RZAT | ATA_SUPPORT_DRAT` in `src/lib/pci_ahci.c`) is returned from an expanded `mirage_block_stat` call, while the `delete` operation itself is plumbed through a new function `mirage_block_delete`.

Since the Mirage Qcow library supports multiple configuration options (and more are going to be added over time), an extra configuration string is plumbed through via the new block parameter `qcow-config=`.

Related to [docker/for-mac#371]