### PR TITLE
circle.yml: Build and test with and without ocaml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,6 +7,9 @@ machine:
     version: "7.3"
 test:
   override:
+    - make clean
+    - make all
+    - make test
     - brew install opam libev
     - opam init --yes
     - opam install --yes uri qcow-format ocamlfind conf-libev


### PR DESCRIPTION
First build and test (which assumes that ocaml is not present in the base
circle image) then install opam etc and do it again with ocaml enabled.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>