### PR TITLE
dtrace script improvements

### DIFF
--- a/dtrace/eptfault.d
+++ b/dtrace/eptfault.d
@@ -9,16 +9,16 @@
 
 dtrace:::BEGIN
 {
-	printf("Tracing... Hit Ctrl-C to end.\n");
+        printf("Tracing... Hit Ctrl-C to end.\n");
 }
 
 hyperkit$target:::vmx-ept-fault
 {
-	@num[arg1, arg0] = count();
+        @num[arg1, arg0] = count();
 }
 
 dtrace:::END
 {
-	printf("%18s %-4s %8s\n", "ADDRESS", "vCPU", "COUNT");
-	printa("%18x %-4d %@8d\n", @num);
+        printf("%18s %-4s %8s\n", "ADDRESS", "vCPU", "COUNT");
+        printa("%18x %-4d %@8d\n", @num);
 }

--- a/dtrace/eptfault.d
+++ b/dtrace/eptfault.d
@@ -62,11 +62,8 @@ hyperkit$target:::vmx-ept-fault
 }
 
 hyperkit$target:::vmx-ept-fault
-/(arg1 & 0xfff00000) != 0xfee00000/
 {
-        // OTHER FAULTS
-
-        @other_faults[arg1, arg0] = count();
+        @all_faults[arg1, arg0] = count();
 }
 
 dtrace:::END
@@ -75,9 +72,9 @@ dtrace:::END
         printf("%18s %-4s %10s\n", "ADDRESS", "vCPU", "COUNT");
         #else
         printf("%18s %-4s %10s\n", "ADDRESS", "vCPU", "RATE (1/s)");
-        normalize(@other_faults, (timestamp - start) / 1000000000);
+        normalize(@all_faults, (timestamp - start) / 1000000000);
         #endif
-        printa("%18x %-4d %@10d\n", @other_faults);
+        printa("%18x %-4d %@10d\n", @all_faults);
 
         #ifdef TOTAL
         printf("%18s %-4s %10s\n", "LAPIC REGISTER", "vCPU", "COUNT");

--- a/dtrace/eptfault.d
+++ b/dtrace/eptfault.d
@@ -7,18 +7,83 @@
 
 #pragma D option quiet
 
+string lapic_map[uint32_t];
+
 dtrace:::BEGIN
 {
+        start = timestamp;
+
+        // from src/include/xhyve/vmm/io/vlapic_priv.h
+        lapic_map[0x20] = "ID";
+        lapic_map[0x30] = "VER";
+        lapic_map[0x80] = "TPR";
+        lapic_map[0x90] = "APR";
+        lapic_map[0xA0] = "PPR";
+        lapic_map[0xB0] = "EOI";
+        lapic_map[0xC0] = "RRR";
+        lapic_map[0xD0] = "LDR";
+        lapic_map[0xE0] = "DFR";
+        lapic_map[0xF0] = "SVR";
+        lapic_map[0x100] = "ISR0";
+        lapic_map[0x110] = "ISR1";
+        lapic_map[0x130] = "ISR3";
+        lapic_map[0x150] = "ISR5";
+        lapic_map[0x170] = "ISR7";
+        lapic_map[0x190] = "TMR1";
+        lapic_map[0x1B0] = "TMR3";
+        lapic_map[0x1D0] = "TMR5";
+        lapic_map[0x1F0] = "TMR7";
+        lapic_map[0x210] = "IRR1";
+        lapic_map[0x230] = "IRR3";
+        lapic_map[0x250] = "IRR5";
+        lapic_map[0x270] = "IRR7";
+        lapic_map[0x2F0] = "CMCI_LVT";
+        lapic_map[0x300] = "ICR_LOW";
+        lapic_map[0x310] = "ICR_HI";
+        lapic_map[0x330] = "THERM_LVT";
+        lapic_map[0x340] = "PERF_LVT";
+        lapic_map[0x350] = "LINT0_LVT";
+        lapic_map[0x360] = "LINT1_LVT";
+        lapic_map[0x370] = "ERROR_LVT";
+        lapic_map[0x380] = "TIMER_ICR";
+        lapic_map[0x390] = "TIMER_CCR";
+        lapic_map[0x3E0] = "TIMER_DCR";
+        lapic_map[0x3F0] = "SELF_IPI";
+
         printf("Tracing... Hit Ctrl-C to end.\n");
 }
 
 hyperkit$target:::vmx-ept-fault
+/(arg1 & 0xfff00000) == 0xfee00000/
 {
-        @num[arg1, arg0] = count();
+        // LAPIC FAULTS
+
+        @lapic_faults[lapic_map[arg1 & 0x000fffff], arg0] = count();
+}
+
+hyperkit$target:::vmx-ept-fault
+/(arg1 & 0xfff00000) != 0xfee00000/
+{
+        // OTHER FAULTS
+
+        @other_faults[arg1, arg0] = count();
 }
 
 dtrace:::END
 {
-        printf("%18s %-4s %8s\n", "ADDRESS", "vCPU", "COUNT");
-        printa("%18x %-4d %@8d\n", @num);
+        #ifdef TOTAL
+        printf("%18s %-4s %10s\n", "ADDRESS", "vCPU", "COUNT");
+        #else
+        printf("%18s %-4s %10s\n", "ADDRESS", "vCPU", "RATE (1/s)");
+        normalize(@other_faults, (timestamp - start) / 1000000000);
+        #endif
+        printa("%18x %-4d %@10d\n", @other_faults);
+
+        #ifdef TOTAL
+        printf("%18s %-4s %10s\n", "LAPIC REGISTER", "vCPU", "COUNT");
+        #else
+        printf("%18s %-4s %10s\n", "LAPIC REGISTER", "vCPU", "RATE (1/s)");
+        normalize(@lapic_faults, (timestamp - start) / 1000000000);
+        #endif
+        printa("%18s %-4d %@10d\n", @lapic_faults);
 }

--- a/dtrace/vmxexit.d
+++ b/dtrace/vmxexit.d
@@ -11,6 +11,8 @@ string reasons[int];
 
 dtrace:::BEGIN
 {
+        start = timestamp;
+
         reasons[0]  = "EXCEPTION";
         reasons[1]  = "EXT_INTR";
         reasons[2]  = "TRIPLE_FAULT";
@@ -76,6 +78,11 @@ hyperkit$target:::vmx-exit
 
 dtrace:::END
 {
+        #ifdef TOTAL
         printf("%16s %-4s %8s\n", "REASON", "vCPU", "COUNT");
+        #else
+        printf("%16s %-4s %8s\n", "REASON", "vCPU", "RATE (1/s)");
+        normalize(@num, (timestamp - start) / 1000000000);
+        #endif
         printa("%16s %-4d %@8d\n", @num);
 }

--- a/dtrace/vmxexit.d
+++ b/dtrace/vmxexit.d
@@ -11,71 +11,71 @@ string reasons[int];
 
 dtrace:::BEGIN
 {
-	reasons[0]  = "EXCEPTION";
-	reasons[1]  = "EXT_INTR";
-	reasons[2]  = "TRIPLE_FAULT";
-	reasons[3]  = "INIT";
-	reasons[4]  = "SIPI";
-	reasons[5]  = "IO_SMI";
-	reasons[6]  = "SMI";
-	reasons[7]  = "INTR_WINDOW";
-	reasons[8]  = "NMI_WINDOW";
-	reasons[9]  = "TASK_SWITCH";
-	reasons[10] = "CPUID";
-	reasons[11] = "GETSEC";
-	reasons[12] = "HLT";
-	reasons[13] = "INVD";
-	reasons[14] = "INVLPG";
-	reasons[15] = "RDPMC";
-	reasons[16] = "RDTSC";
-	reasons[17] = "RSM";
-	reasons[18] = "VMCALL";
-	reasons[19] = "VMCLEAR";
-	reasons[20] = "VMLAUNCH";
-	reasons[21] = "VMPTRLD";
-	reasons[22] = "VMPTRST";
-	reasons[23] = "VMREAD";
-	reasons[24] = "VMRESUME";
-	reasons[25] = "VMWRITE";
-	reasons[26] = "VMXOFF";
-	reasons[27] = "VMXON";
-	reasons[28] = "CR_ACCESS";
-	reasons[29] = "DR_ACCESS";
-	reasons[30] = "INOUT";
-	reasons[31] = "RDMSR";
-	reasons[32] = "WRMSR";
-	reasons[33] = "INVAL_VMCS";
-	reasons[34] = "INVAL_MSR";
-	reasons[36] = "MWAIT";
-	reasons[37] = "MTF";
-	reasons[39] = "MONITOR";
-	reasons[40] = "PAUSE";
-	reasons[41] = "MCE_DURING_ENTRY";
-	reasons[43] = "TPR";
-	reasons[44] = "APIC_ACCESS";
-	reasons[45] = "VIRTUALIZED_EOI";
-	reasons[46] = "GDTR_IDTR";
-	reasons[47] = "LDTR_TR";
-	reasons[48] = "EPT_FAULT";
-	reasons[49] = "EPT_MISCONFIG";
-	reasons[50] = "INVEPT";
-	reasons[51] = "RDTSCP";
-	reasons[52] = "VMX_PREEMPT";
-	reasons[53] = "INVVPID";
-	reasons[54] = "WBINVD";
-	reasons[55] = "XSETBV";
-	reasons[56] = "APIC_WRITE";
+        reasons[0]  = "EXCEPTION";
+        reasons[1]  = "EXT_INTR";
+        reasons[2]  = "TRIPLE_FAULT";
+        reasons[3]  = "INIT";
+        reasons[4]  = "SIPI";
+        reasons[5]  = "IO_SMI";
+        reasons[6]  = "SMI";
+        reasons[7]  = "INTR_WINDOW";
+        reasons[8]  = "NMI_WINDOW";
+        reasons[9]  = "TASK_SWITCH";
+        reasons[10] = "CPUID";
+        reasons[11] = "GETSEC";
+        reasons[12] = "HLT";
+        reasons[13] = "INVD";
+        reasons[14] = "INVLPG";
+        reasons[15] = "RDPMC";
+        reasons[16] = "RDTSC";
+        reasons[17] = "RSM";
+        reasons[18] = "VMCALL";
+        reasons[19] = "VMCLEAR";
+        reasons[20] = "VMLAUNCH";
+        reasons[21] = "VMPTRLD";
+        reasons[22] = "VMPTRST";
+        reasons[23] = "VMREAD";
+        reasons[24] = "VMRESUME";
+        reasons[25] = "VMWRITE";
+        reasons[26] = "VMXOFF";
+        reasons[27] = "VMXON";
+        reasons[28] = "CR_ACCESS";
+        reasons[29] = "DR_ACCESS";
+        reasons[30] = "INOUT";
+        reasons[31] = "RDMSR";
+        reasons[32] = "WRMSR";
+        reasons[33] = "INVAL_VMCS";
+        reasons[34] = "INVAL_MSR";
+        reasons[36] = "MWAIT";
+        reasons[37] = "MTF";
+        reasons[39] = "MONITOR";
+        reasons[40] = "PAUSE";
+        reasons[41] = "MCE_DURING_ENTRY";
+        reasons[43] = "TPR";
+        reasons[44] = "APIC_ACCESS";
+        reasons[45] = "VIRTUALIZED_EOI";
+        reasons[46] = "GDTR_IDTR";
+        reasons[47] = "LDTR_TR";
+        reasons[48] = "EPT_FAULT";
+        reasons[49] = "EPT_MISCONFIG";
+        reasons[50] = "INVEPT";
+        reasons[51] = "RDTSCP";
+        reasons[52] = "VMX_PREEMPT";
+        reasons[53] = "INVVPID";
+        reasons[54] = "WBINVD";
+        reasons[55] = "XSETBV";
+        reasons[56] = "APIC_WRITE";
 
-	printf("Tracing... Hit Ctrl-C to end.\n");
+        printf("Tracing... Hit Ctrl-C to end.\n");
 }
 
 hyperkit$target:::vmx-exit
 {
-	@num[reasons[arg1], arg0] = count();
+        @num[reasons[arg1], arg0] = count();
 }
 
 dtrace:::END
 {
-	printf("%16s %-4s %8s\n", "REASON", "vCPU", "COUNT");
-	printa("%16s %-4d %@8d\n", @num);
+        printf("%16s %-4s %8s\n", "REASON", "vCPU", "COUNT");
+        printa("%16s %-4d %@8d\n", @num);
 }


### PR DESCRIPTION
This patchset adds rate counting modes (default, accumulator mode with `-DTOTAL`) to the `vmxexit.d` and `eptfault.d` dtrace scripts and a LAPIC register decoder to `eptfault.d`. These changes make steady-state performance comparison and EPT fault analysis easier.

Sorry about the repo branch. I'll make a fork for next time.