### PR TITLE
vsock: correctly account partial writes on tx

### DIFF
--- a/src/lib/pci_virtio_sock.c
+++ b/src/lib/pci_virtio_sock.c
@@ -1100,8 +1100,8 @@ static int handle_write(struct pci_vtsock_softc *sc,
 	}
 
 	DPRINTF(("TX: wrote %zd/%"PRId32" bytes\n", num, len));
+	sock->fwd_cnt += num;
 	if (num == len) {
-		sock->fwd_cnt += num;
 		return 1;
 	} else { /* Buffer the rest */
 		size_t pulled = iovec_pull(&iov, &iov_len, NULL, (size_t)num);


### PR DESCRIPTION
When buffering due to a partially successful write we need to add the
successful part of the write to fwd_cnt otherwise we miss those bytes in our
accounting and will eventually fall behind enough that we think we cannot
forward any more traffic.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>

With this in place the mysql test case in https://github.com/docker/for-mac/issues/825 now succeeds for me.