### PR TITLE
ocaml: initialise the logging system used by the qcow library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ FIRMWARE_LIB_SRC := \
 
 HYPERKIT_SRC := src/hyperkit.c
 
-HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow uri >/dev/null 2>/dev/null ; then echo YES ; else echo NO; fi)
+HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow uri logs logs.fmt >/dev/null 2>/dev/null ; then echo YES ; else echo NO; fi)
 
 ifeq ($(HAVE_OCAML_QCOW),YES)
 CFLAGS += -DHAVE_OCAML=1 -DHAVE_OCAML_QCOW=1 -DHAVE_OCAML=1
@@ -102,7 +102,8 @@ OCAML_C_SRC := \
 	src/lib/mirage_block_c.c
 
 OCAML_WHERE := $(shell ocamlc -where)
-OCAML_PACKS := cstruct cstruct.lwt io-page io-page.unix uri mirage-block mirage-block-unix qcow unix threads lwt lwt.unix
+OCAML_PACKS := cstruct cstruct.lwt io-page io-page.unix uri mirage-block \
+	mirage-block-unix qcow unix threads lwt lwt.unix logs logs.fmt
 OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query cstruct)/cstruct.a \
 	$(shell ocamlfind query cstruct)/libcstruct_stubs.a \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow conf-libev
+    $ opam install uri qcow conf-libev logs fmt
 
 Notes:
 

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow ocamlfind conf-libev
+    - opam install --yes uri qcow ocamlfind conf-libev logs fmt
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -1,3 +1,12 @@
+(* Initialise logging *)
+let src =
+  Logs.set_reporter (Logs_fmt.reporter ());
+  let src = Logs.Src.create "mirage" ~doc:"mirage block device interface" in
+  Logs.Src.set_level src (Some Logs.Info);
+  src
+module Log = (val Logs.src_log src : Logs.LOG)
+
+
 (* TODO: parameterise this over block implementations *)
 module Qcow = Qcow.Make(Block)
 


### PR DESCRIPTION
Previously the qcow library could emit errors and warnings but these would be dropped since the logging system wasn't initialised. This patch should cause these messages to be printed to stderr, along with the other output from hyperkit.

Signed-off-by: David Scott <dave.scott@docker.com>