### PR TITLE
ocaml: qcow-config should be optional

### DIFF
--- a/src/lib/mirage_block_c.c
+++ b/src/lib/mirage_block_c.c
@@ -48,11 +48,17 @@ if (fn == NULL) { \
 static void
 ocaml_mirage_block_open(const char *config, const char *options, int *out, int *err) {
 	CAMLparam0();
-	CAMLlocal3(ocaml_config, ocaml_options, handle);
+	CAMLlocal4(ocaml_config, ocaml_options_opt, ocaml_string, handle);
 	ocaml_config = caml_copy_string(config);
-	ocaml_options = caml_copy_string(options);
+	if (options == NULL) {
+		ocaml_options_opt = Val_int(0); /* None */
+	} else {
+		ocaml_string = caml_copy_string(options);
+		ocaml_options_opt = caml_alloc(1, 0); /* Some */
+		Store_field (ocaml_options_opt, 0, ocaml_string);
+	}
 	OCAML_NAMED_FUNCTION("mirage_block_open")
-	handle = caml_callback2_exn(*fn, ocaml_config, ocaml_options);
+	handle = caml_callback2_exn(*fn, ocaml_config, ocaml_options_opt);
 	if (Is_exception_result(handle)){
 		*err = 1;
 	} else {

--- a/src/lib/mirage_block_c.h
+++ b/src/lib/mirage_block_c.h
@@ -31,7 +31,8 @@ mirage_block_unregister_thread(void);
 /* An opened mirage-block device */
 typedef int mirage_block_handle;
 
-/* Open a mirage block device with the given string configuration. */
+/* Open a mirage block device with the given optional string configuration.
+   To use the default configuration, pass NULL for options. */
 extern mirage_block_handle
 mirage_block_open(const char *config, const char *options);
 


### PR DESCRIPTION
This patch fixes a segfault triggered by setting `format=qcow` but not providing a `qcow-config` parameter. The Mirage qcow interface already treats this configuration as an optional value. This patch modifies the C -> OCaml interface to map NULL onto None.

Fixes #88

Signed-off-by: David Scott <dave.scott@docker.com>