### PR TITLE
Add some qcow-related tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /test/vmlinuz
 /test/initrd
 /test/initrd.gz
+/test/disk.qcow2

--- a/Makefile
+++ b/Makefile
@@ -178,9 +178,13 @@ clean:
 	@rm -rf build
 	@rm -f src/include/xhyve/dtrace.h
 	@rm -f test/vmlinuz test/initrd.gz
+	@rm -f test/disk.qcow2
 
 test/vmlinuz test/initrd.gz:
 	@cd test; ./tinycore.sh
 
 test: $(TARGET) test/vmlinuz test/initrd.gz
 	@(cd test && ./test_linux.exp)
+ifeq ($(HAVE_OCAML_QCOW),YES)
+	@(cd test && ./test_linux_qcow.exp)
+endif

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ TARGET = build/com.docker.hyperkit
 
 all: $(TARGET) | build
 
-.PHONY: clean all test
+.PHONY: clean all test test-qcow
 .SUFFIXES:
 
 -include $(DEP)
@@ -185,6 +185,6 @@ test/vmlinuz test/initrd.gz:
 
 test: $(TARGET) test/vmlinuz test/initrd.gz
 	@(cd test && ./test_linux.exp)
-ifeq ($(HAVE_OCAML_QCOW),YES)
+
+test-qcow: $(TARGET) test/vmlinuz test/initrd.gz
 	@(cd test && ./test_linux_qcow.exp)
-endif

--- a/circle.yml
+++ b/circle.yml
@@ -9,6 +9,7 @@ test:
   override:
     - make clean
     - make all
+    - test ! -s build/lib/mirage_block_ocaml.cmi || (echo "qcow libraries have been pre-installed in CI environment" && exit 1)
     - make test
     - brew install opam libev
     - opam init --yes

--- a/circle.yml
+++ b/circle.yml
@@ -17,3 +17,4 @@ test:
     - make clean
     - eval `opam config env` && make all
     - make test
+    - eval `opam config env` && make test-qcow

--- a/test/test_linux_qcow.exp
+++ b/test/test_linux_qcow.exp
@@ -1,0 +1,37 @@
+#!/usr/bin/env expect
+
+set KERNEL "./vmlinuz"
+set INITRD "./initrd.gz"
+set CMDLINE "earlyprintk=serial console=ttyS0"
+
+exec qcow-tool create --size 1GiB disk.qcow2
+set PWD [ exec pwd ]
+
+spawn ../build/com.docker.hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,file:///$PWD/disk.qcow2,format=qcow -f kexec,$KERNEL,$INITRD,$CMDLINE
+set pid [exp_pid]
+set timeout 20
+
+expect {
+  timeout {puts "FAIL boot"; exec kill -9 $pid; exit 1}
+  "\r\ntc@box:~$ "
+}
+send "echo 'This is a block device' > /dev/sda\r\n"
+send "sync\r\n"
+send "sudo halt\r\n";
+expect {
+  timeout {puts "FAIL shutdown"; exec kill -9 $pid; exit 1}
+  "reboot: System halted"
+}
+close
+
+spawn qcow-tool read --sector=0 $PWD/disk.qcow2
+set pid [exp_pid]
+set timeout 20
+
+expect {
+  timeout {puts "FAIL qcow-tool"; exec kill -9 $pid; exit 1}
+  "This is a block device" { puts "\n\nPASS"; exit 0}
+}
+
+puts "\n\nFAIL failed to read data from qcow"
+exit 1


### PR DESCRIPTION
- verify that we can boot up a VM with a .qcow2-backed block device and successfully write to it
- check that the without-qcow build really is without-qcow: this will fail if the CI base image were ever to have the qcow dependencies installed in it

Tests #88 