### PR TITLE
ocaml: qcow >= 0.7.0 is functorised over Time

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow conf-libev logs fmt
+    $ opam install uri qcow.0.7.0 conf-libev logs fmt
 
 Notes:
 

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,7 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow ocamlfind conf-libev logs fmt
+    - opam install --yes uri qcow.0.7.0 ocamlfind conf-libev logs fmt
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -8,7 +8,11 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 
 (* TODO: parameterise this over block implementations *)
-module Qcow = Qcow.Make(Block)
+module Time = struct
+  type 'a io = 'a Lwt.t
+  let sleep = Lwt_unix.sleep
+end
+module Qcow = Qcow.Make(Block)(Time)
 
 module Mutex = struct
   include Mutex


### PR DESCRIPTION
Modern versions of `qcow` when configured to automatically compact will wait until there have been no `discard`s for some period of time in order to batch a run of `discard`s together.

Signed-off-by: David Scott <dave.scott@docker.com>