### PR TITLE
Dump guest physical and linear address from VMCS when dumping state

### DIFF
--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -179,6 +179,10 @@ static void hvdump(int vcpu) {
 		vmcs_read(vcpu, VMCS_CR4_MASK));
 	printf("VMCS_CR4_SHADOW:               0x%016llx\n",
 		vmcs_read(vcpu, VMCS_CR4_SHADOW));
+	printf("VMCS_GUEST_PHYSICAL_ADDRESS:   0x%016llx\n",
+	       vmcs_read(vcpu, VMCS_GUEST_PHYSICAL_ADDRESS));
+	printf("VMCS_GUEST_LINEAR_ADDRESS:     0x%016llx\n",
+	       vmcs_read(vcpu, VMCS_GUEST_LINEAR_ADDRESS));
 	printf("VMCS_GUEST_CS_SELECTOR:        0x%016llx\n",
 		vmcs_read(vcpu, VMCS_GUEST_CS_SELECTOR));
 	printf("VMCS_GUEST_CS_LIMIT:           0x%016llx\n",


### PR DESCRIPTION
These may or may not be valid for a particular fault but other
information which is already logged (such as the vmexit qualification)
should allow a developer to work out if the values are valid on a case
by case basis.

Signed-off-by: Ian Campbell <ian.campbell@docker.com>