### PR TITLE
Update to Mirage 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ FIRMWARE_LIB_SRC := \
 
 HYPERKIT_SRC := src/hyperkit.c
 
-HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow uri logs logs.fmt >/dev/null 2>/dev/null ; then echo YES ; else echo NO; fi)
+HAVE_OCAML_QCOW := $(shell if ocamlfind query qcow uri logs logs.fmt mirage-unix >/dev/null 2>/dev/null ; then echo YES ; else echo NO; fi)
 
 ifeq ($(HAVE_OCAML_QCOW),YES)
 CFLAGS += -DHAVE_OCAML=1 -DHAVE_OCAML_QCOW=1 -DHAVE_OCAML=1
@@ -103,7 +103,8 @@ OCAML_C_SRC := \
 
 OCAML_WHERE := $(shell ocamlc -where)
 OCAML_PACKS := cstruct cstruct.lwt io-page io-page.unix uri mirage-block \
-	mirage-block-unix qcow unix threads lwt lwt.unix logs logs.fmt
+	mirage-block-unix qcow unix threads lwt lwt.unix logs logs.fmt   \
+	mirage-unix
 OCAML_LDLIBS := -L $(OCAML_WHERE) \
 	$(shell ocamlfind query cstruct)/cstruct.a \
 	$(shell ocamlfind query cstruct)/libcstruct_stubs.a \

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ opam init
     $ eval `opam config env`
     $ opam remote add mirageos-3-beta git://github.com/mirage/mirageos-3-beta
-    $ opam install uri qcow.0.8.1 mirage-block-unix.2.6.0 conf-libev logs fmt
+    $ opam install uri qcow.0.8.1 mirage-block-unix.2.6.0 conf-libev logs fmt mirage-unix
 
 Notes:
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam install uri qcow.0.7.0 conf-libev logs fmt
+    $ opam remote add mirageos-3-beta git://github.com/mirage/mirageos-3-beta
+    $ opam install uri qcow.0.8.1 mirage-block-unix.2.6.0 conf-libev logs fmt
 
 Notes:
 

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ test:
     - brew install opam libev
     - opam init --yes
     - opam remote add mirageos-3-beta git://github.com/mirage/mirageos-3-beta
-    - opam install --yes uri qcow.0.8.1 mirage-block-unix.2.6.0 ocamlfind conf-libev logs fmt
+    - opam install --yes uri qcow.0.8.1 mirage-block-unix.2.6.0 ocamlfind conf-libev logs fmt mirage-unix
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,8 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam install --yes uri qcow.0.7.0 ocamlfind conf-libev logs fmt
+    - opam remote add mirageos-3-beta git://github.com/mirage/mirageos-3-beta
+    - opam install --yes uri qcow.0.8.1 mirage-block-unix.2.6.0 ocamlfind conf-libev logs fmt
     - make clean
     - eval `opam config env` && make all
     - make test

--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -8,11 +8,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 
 
 (* TODO: parameterise this over block implementations *)
-module Time = struct
-  type 'a io = 'a Lwt.t
-  let sleep_ns ns = Lwt_unix.sleep (Int64.to_float ns /. 1e9)
-end
-module Qcow = Qcow.Make(Block)(Time)
+module Qcow = Qcow.Make(Block)(OS.Time)
 
 module Mutex = struct
   include Mutex

--- a/src/lib/mirage_block_ocaml.ml
+++ b/src/lib/mirage_block_ocaml.ml
@@ -10,7 +10,7 @@ module Log = (val Logs.src_log src : Logs.LOG)
 (* TODO: parameterise this over block implementations *)
 module Time = struct
   type 'a io = 'a Lwt.t
-  let sleep = Lwt_unix.sleep
+  let sleep_ns ns = Lwt_unix.sleep (Int64.to_float ns /. 1e9)
 end
 module Qcow = Qcow.Make(Block)(Time)
 
@@ -88,7 +88,7 @@ module Protocol = struct
       | Write of int
       | Delete
       | Flush
-    type t = [ `Ok of ok | `Error of Qcow.error ]
+    type t = (ok, Qcow.write_error) result
   end
 
   (* An in-flight request *)
@@ -148,29 +148,29 @@ module C = struct
       allowed to block. *)
 
   let string_of_error = function
-    | `Unknown x -> Printf.sprintf "Unknown %s" x
     | `Unimplemented -> "Operation is not implemented"
     | `Is_read_only -> "Block device is read-only"
     | `Disconnected -> "Block device is disconnected"
+    | _ -> "Unknown error"
 
   let ok_exn = function
-    | `Error x ->
+    | Error x ->
       Printf.fprintf stderr "Mirage-block error: %s\n%!" (string_of_error x);
-      raise (Mirage_block.Error.Error x)
-    | `Ok x -> x
+      failwith (string_of_error x)
+    | Ok x -> x
 
   let mirage_block_open block_config qcow_config_opt : int =
     let description = Printf.sprintf "block_config = %s and qcow_config = %s"
       block_config (match qcow_config_opt with None -> "None" | Some x -> x) in
     Printf.fprintf stdout "mirage_block_open: %s\n%!" description;
     match Block.Config.of_string block_config with
-      | `Ok block_config' ->
+      | Ok block_config' ->
         let qcow_config' = match qcow_config_opt with
           | None -> None
           | Some x ->
             begin match Qcow.Config.of_string x with
-              | `Ok qcow_config' -> Some qcow_config'
-              | `Error (`Msg m) ->
+              | Ok qcow_config' -> Some qcow_config'
+              | Error (`Msg m) ->
                 Printf.fprintf stderr "mirage_block_option %s: %s\n%!" description m;
                 exit 1
             end in
@@ -182,7 +182,7 @@ module C = struct
             Printf.fprintf stderr "protocol error: unexpected response to connect\n%!";
             exit 1
         end
-      | `Error (`Msg m) ->
+      | Error (`Msg m) ->
         Printf.fprintf stderr "mirage_block_open %s: %s\n%!" description m;
         exit 1
 
@@ -254,7 +254,7 @@ module Handle = struct
   type t = {
     base: Block.t;
     block: Qcow.t;
-    info: Qcow.info;
+    info: Mirage_block.info;
   }
 
   let table = Hashtbl.create 7
@@ -285,58 +285,69 @@ open Lwt
    the Ivar. *)
 let process_one t =
   let open Protocol in
-  let open Mirage_block.Error.Monad in
-  let open Mirage_block.Error.Monad.Infix in
+  let module Monad = struct
+    let (>>=) m f =
+      let open Lwt.Infix in
+      m >>= function
+      | Error e -> Lwt.return (Error e)
+      | Ok x -> f x
+    let return x = Lwt.return (Ok x)
+  end in
+  let open Monad in
   let result_t =
     Lwt.catch
       (fun () ->
         match t.request with
           | Request.Connect (block_config, qcow_config) ->
+            let open Lwt.Infix in
             Block.of_config block_config
             >>= fun base ->
             Qcow.connect ?config:qcow_config base
             >>= fun block ->
-            ( let open Lwt in
-              Qcow.get_info block
-              >>= fun info ->
-              return (`Ok info) )
+            Qcow.get_info block
             >>= fun info ->
             let h = Handle.register { Handle.block; base; info } in
             return (Response.Connect h)
           | Request.Get_info h ->
             let t = Handle.find_or_quit h in
-            let open Lwt in
+            let open Lwt.Infix in
             Qcow.get_info t.Handle.block
             >>= fun info ->
             let config = Qcow.to_config t.Handle.block in
             let candelete = config.Qcow.Config.discard in
-            return (`Ok (Response.Get_info (info.Qcow.read_write, info.Qcow.sector_size, info.Qcow.size_sectors, candelete)))
+            return (Response.Get_info (info.Mirage_block.read_write, info.Mirage_block.sector_size, info.Mirage_block.size_sectors, candelete))
           | Request.Disconnect h ->
             let t = Handle.find_or_quit h in
-            let open Lwt in
+            let open Lwt.Infix in
             Qcow.disconnect t.Handle.block
             >>= fun () ->
-            return (`Ok Response.Disconnect)
+            return Response.Disconnect
           | Request.Read (h, offset, bufs) ->
             let t = Handle.find_or_quit h in
             (* Offset needs to be translated into sectors *)
-            if offset mod t.Handle.info.Qcow.sector_size <> 0 then begin
+            if offset mod t.Handle.info.Mirage_block.sector_size <> 0 then begin
               Printf.fprintf stderr "Read offset not at sector boundary\n%!";
               exit 1
             end;
-            let sector = Int64.of_int (offset / t.Handle.info.Qcow.sector_size) in
-            Qcow.read t.Handle.block sector bufs
-            >>= fun () ->
-            let len = List.(fold_left (+) 0 (map Cstruct.len bufs)) in
-            return (Response.Read len)
+            let sector = Int64.of_int (offset / t.Handle.info.Mirage_block.sector_size) in
+            let open Lwt.Infix in
+            (* Qcow.error <> Qcow.write_error *)
+            begin Qcow.read t.Handle.block sector bufs
+              >>= function
+              | Error `Disconnected -> Lwt.return (Error `Disconnected)
+              | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
+              | Ok () ->
+              let len = List.(fold_left (+) 0 (map Cstruct.len bufs)) in
+              return (Response.Read len)
+            end
           | Request.Write (h, offset, bufs) ->
             let t = Handle.find_or_quit h in
             (* Offset needs to be translated into sectors *)
-            if offset mod t.Handle.info.Qcow.sector_size <> 0 then begin
+            if offset mod t.Handle.info.Mirage_block.sector_size <> 0 then begin
               Printf.fprintf stderr "Write offset not at sector boundary\n%!";
               exit 1
             end;
-            let sector = Int64.of_int (offset / t.Handle.info.Qcow.sector_size) in
+            let sector = Int64.of_int (offset / t.Handle.info.Mirage_block.sector_size) in
             Qcow.write t.Handle.block sector bufs
             >>= fun () ->
             let len = List.(fold_left (+) 0 (map Cstruct.len bufs)) in
@@ -344,7 +355,7 @@ let process_one t =
           | Request.Delete (h, offset, len) ->
             let t = Handle.find_or_quit h in
             (* Offset and len need to be translated into sectors *)
-            let sector_size = Int64.of_int t.Handle.info.Qcow.sector_size in
+            let sector_size = Int64.of_int t.Handle.info.Mirage_block.sector_size in
             if Int64.rem offset sector_size <> 0L then begin
               Printf.fprintf stderr "Delete offset not at sector boundary\n%!";
               exit 1
@@ -360,16 +371,23 @@ let process_one t =
             return Response.Delete
           | Request.Flush h ->
             let t = Handle.find_or_quit h in
-            Block.flush t.Handle.base
-            >>= fun () ->
-            return Response.Flush
+            let open Lwt.Infix in
+            (* Block.write_error <> Qcow.write_error *)
+            begin Block.flush t.Handle.base
+              >>= function
+              | Error `Disconnected -> Lwt.return (Error `Disconnected)
+              | Error `Is_read_only -> Lwt.return (Error `Is_read_only)
+              | Error `Unimplemented -> Lwt.return (Error `Unimplemented)
+              | Ok () ->
+                return Response.Flush
+            end
       )
       (fun e ->
         (* If the thread fails unexpectedly then convert this into an Error return
            to guarantee we return an error code to the block interface instead of
            dropping the request on the floor. *)
         Log.err (fun f -> f "Mirage block device raised exception: %s" (Printexc.to_string e));
-        Lwt.return (`Error (`Unknown (Printexc.to_string e)))
+        Lwt.return (Error `Disconnected)
       ) in
   let open Lwt in
   result_t >>= fun result ->


### PR DESCRIPTION
This PR updates to the new Mirage v3 block API and includes the latest version of the `qcow` library which supports flushing via `fsync` as well as `fcntl`: see [docker/for-mac#668]

Note the Mirage 3 packages have been tagged and released but the package metadata is in a new repository: https://github.com/mirage/mirageos-3-beta. This PR updates the `circle.yml` and the instructions in the `README.md` accordingly.