### PR TITLE
Rename com.docker.hyperkit to hyperkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ INC := -Isrc/include
 
 CFLAGS += -DVERSION=\"$(GIT_VERSION)\" -DVERSION_SHA1=\"$(GIT_VERSION_SHA1)\"
 
-TARGET = build/com.docker.hyperkit
+TARGET = build/hyperkit
 
 all: $(TARGET) | build
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you are using Hyperkit directly then please report issues against this reposi
 
 ## Usage
 
-    $ com.docker.hyperkit -h
+    $ hyperkit -h
 
 ## Building
 
@@ -28,7 +28,7 @@ If you are using Hyperkit directly then please report issues against this reposi
     $ cd hyperkit
     $ make
 
-The resulting binary will be in `build/com.docker.hyperkit`
+The resulting binary will be in `build/hyperkit`
 
 To enable qcow support in the block backend an OCaml [OPAM](https://opam.ocaml.org) development
 environment is required with the qcow module available. A

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 general:
   artifacts:
-    - build/com.docker.hyperkit
-    - build/com.docker.hyperkit.sym
+    - build/hyperkit
+    - build/hyperkit.sym
 machine:
   xcode:
     version: "7.3"

--- a/dtrace/eptfault.d
+++ b/dtrace/eptfault.d
@@ -2,7 +2,7 @@
 /*
  * eptfault.d - report all EPT faults for particular VM
  *
- * USAGE: eptfault.d -p <pid of com.docker.hyperkit>
+ * USAGE: eptfault.d -p <pid of hyperkit>
  */
 
 #pragma D option quiet

--- a/dtrace/vmxexit.d
+++ b/dtrace/vmxexit.d
@@ -2,7 +2,7 @@
 /*
  * vmxexit.d - report all VMX exits for particular VM
  *
- * USAGE: vmxexit.d -p <pid of com.docker.hyperkit>
+ * USAGE: vmxexit.d -p <pid of hyperkit>
  */
 
 #pragma D option quiet

--- a/hyperkitrun.sh
+++ b/hyperkitrun.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-HYPERKIT="build/com.docker.hyperkit"
+HYPERKIT="build/hyperkit"
 
 # Linux
 KERNEL="test/vmlinuz"
@@ -36,7 +36,7 @@ if [ ! -f "$KERNEL" ]; then
  ./tinycore.sh
  popd
 fi
-build/com.docker.hyperkit $ACPI $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_CD $IMG_HDD $UUID -f kexec,$KERNEL,$INITRD,"$CMDLINE"
+build/hyperkit $ACPI $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_CD $IMG_HDD $UUID -f kexec,$KERNEL,$INITRD,"$CMDLINE"
 
 # FreeBSD
-#build/com.docker.hyperkit $ACPI $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_CD $IMG_HDD $UUID -f fbsd,$USERBOOT,$BOOTVOLUME,"$KERNELENV"
+#build/hyperkit $ACPI $MEM $SMP $PCI_DEV $LPC_DEV $NET $IMG_CD $IMG_HDD $UUID -f fbsd,$USERBOOT,$BOOTVOLUME,"$KERNELENV"

--- a/test/test_linux.exp
+++ b/test/test_linux.exp
@@ -8,7 +8,7 @@ exec hdiutil create -megabytes 20 -fs "MS-DOS" disk
 set DISK [exec hdiutil attach -nomount -noverify -noautofsck disk.dmg | head -n1 | cut -f1 -d " "]
 set RDISK [string map { disk rdisk } $DISK]
 
-spawn ../build/com.docker.hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,$RDISK -f kexec,$KERNEL,$INITRD,$CMDLINE
+spawn ../build/hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,$RDISK -f kexec,$KERNEL,$INITRD,$CMDLINE
 set pid [exp_pid]
 set timeout 20
 

--- a/test/test_linux_qcow.exp
+++ b/test/test_linux_qcow.exp
@@ -7,7 +7,7 @@ set CMDLINE "earlyprintk=serial console=ttyS0"
 exec qcow-tool create --size 1GiB disk.qcow2
 set PWD [ exec pwd ]
 
-spawn ../build/com.docker.hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,file:///$PWD/disk.qcow2,format=qcow -f kexec,$KERNEL,$INITRD,$CMDLINE
+spawn ../build/hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,file:///$PWD/disk.qcow2,format=qcow -f kexec,$KERNEL,$INITRD,$CMDLINE
 set pid [exp_pid]
 set timeout 20
 


### PR DESCRIPTION
The name `hyperkit`

- is a more conventional format name
- matches the name of the github repo
- is shorter and easier to type
- is consistent with vpnkit (repo = vpnkit; binary = vpnkit)

Signed-off-by: David Scott <dave.scott@docker.com>