### PR TITLE
ocaml: remove the mirageos-3-beta repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ via `brew` and using `opam` to install the appropriate libraries:
     $ brew install opam libev
     $ opam init
     $ eval `opam config env`
-    $ opam remote add mirageos-3-beta git://github.com/mirage/mirageos-3-beta
     $ opam install uri qcow.0.8.1 mirage-block-unix.2.6.0 conf-libev logs fmt mirage-unix
 
 Notes:

--- a/circle.yml
+++ b/circle.yml
@@ -13,7 +13,6 @@ test:
     - make test
     - brew install opam libev
     - opam init --yes
-    - opam remote add mirageos-3-beta git://github.com/mirage/mirageos-3-beta
     - opam install --yes uri qcow.0.8.1 mirage-block-unix.2.6.0 ocamlfind conf-libev logs fmt mirage-unix
     - make clean
     - eval `opam config env` && make all


### PR DESCRIPTION
This code has all been released upstream and the repo has been removed.

Signed-off-by: David Scott <dave.scott@docker.com>