### PR TITLE
Add another default hyperkit path

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -60,6 +60,7 @@ const (
 var defaultHyperKits = []string{"hyperkit",
 	"com.docker.hyperkit",
 	"/usr/local/bin/hyperkit",
+	"/Applications/Docker.app/Contents/Resources/bin/hyperkit",
 	"/Applications/Docker.app/Contents/MacOS/com.docker.hyperkit"}
 
 // HyperKit contains the configuration of the hyperkit VM


### PR DESCRIPTION
This is used in most recent Docker for Mac.

Signed-off-by: Justin Cormack <justin.cormack@docker.com>