### PR TITLE
Change the exit codes to something saner

### DIFF
--- a/hyperkit.1
+++ b/hyperkit.1
@@ -356,6 +356,24 @@ hyperkit -c 4 \\
 
 .Ed
 
+.Sh EXIT STATUS
+The
+.Nm hyperkit
+process exits with one of the following values:
+.Pp
+.Bl -tag -width flag -compact
+.It Li 0
+The guest either powered down or halted cleanly.
+.It Li 1
+An error occurred.
+.It Li 2
+The guest rebooted/reset. The caller is responsible for starting a new hyperkit process in this case.
+.It Li 3
+A triple fault occurred.
+.It Li 100
+An invalid/unknown VM exit occurred.
+.El
+
 .Sh SIGNALS
 .Bl -tag -width 10n
 .It Pa SIGUSR1

--- a/src/hyperkit.c
+++ b/src/hyperkit.c
@@ -530,11 +530,10 @@ vmexit_suspend(struct vm_exit *vme, int *pvcpu)
 	pthread_mutex_unlock(&resetcpu_mtx);
 
 	switch ((int) (how)) {
-	case VM_SUSPEND_RESET:
-		exit(0);
 	case VM_SUSPEND_POWEROFF:
-		exit(1);
 	case VM_SUSPEND_HALT:
+		exit(0);
+	case VM_SUSPEND_RESET:
 		exit(2);
 	case VM_SUSPEND_TRIPLEFAULT:
 		exit(3);

--- a/src/lib/acpitbl.c
+++ b/src/lib/acpitbl.c
@@ -737,7 +737,7 @@ void dsdt_fixup(int bus, uint16_t iobase, uint16_t iolimit, uint32_t membase32,
 {
 	if (bus != 0) {
 		fprintf(stderr, "DSDT, unsupported PCI bus (%d)\n", bus);
-		exit(-1);
+		exit(1);
 	}
 
 	acpitbl_write16(dsdt, 0xb6, iobase);

--- a/src/lib/firmware/bootrom.c
+++ b/src/lib/firmware/bootrom.c
@@ -119,7 +119,7 @@ done:
 	if (fd >= 0)
 		close(fd);
 	if (rv)
-		exit(-1);
+		exit(1);
 	return 0xfff0;
 }
 

--- a/src/lib/firmware/fbsd.c
+++ b/src/lib/firmware/fbsd.c
@@ -793,7 +793,7 @@ cb_exit(void)
 {
 	tcsetattr(consout_fd, TCSAFLUSH, &oldterm);
 	fprintf(stderr, "fbsd: error\n");
-	exit(-1);
+	exit(1);
 }
 
 static void
@@ -955,7 +955,7 @@ fbsd_load(void)
 		disk_open(config.bootvolume);
 	} else {
 		fprintf(stderr, "fbsd: no boot volume\n");
-		exit(-1);
+		exit(1);
 	}
 
 	if (config.kernelenv) {
@@ -974,13 +974,13 @@ fbsd_load(void)
 	h = dlopen(config.userboot, RTLD_LOCAL);
 	if (!h) {
 		fprintf(stderr, "%s\n", dlerror());
-		exit(-1);
+		exit(1);
 	}
 
 	func = (func_t) dlsym(h, "loader_main");
 	if (!func) {
 		fprintf(stderr, "%s\n", dlerror());
-		exit(-1);
+		exit(1);
 	}
 
 	addenv("smbios.bios.vendor=BHYVE");

--- a/src/lib/mevent.c
+++ b/src/lib/mevent.c
@@ -408,7 +408,7 @@ mevent_dispatch(void)
 	ret = pipe(mevent_pipefd);
 	if (ret < 0) {
 		perror("pipe");
-		exit(0);
+		exit(1);
 	}
 
 	/*


### PR DESCRIPTION
- Use 0 for both poweroff and halt. They are more or less the same.
- Use 2 when the guest rebooted. This allows the user to restart
  the process, possibly with some changes, such as removing a
  CDROM device.

The other exit codes are untouched.

Also document the exit codes in the man page while at it.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>

resolves #108