### PR TITLE
Remove "-M"/"print_mac" option.

### DIFF
--- a/src/hyperkit.c
+++ b/src/hyperkit.c
@@ -88,7 +88,6 @@ extern int vmexit_task_switch(struct vm_exit *, int *vcpu);
 char *vmname = "vm";
 
 int guest_ncpus;
-int print_mac;
 char *guest_uuid_str;
 static char *pidfile;
 
@@ -860,7 +859,6 @@ main(int argc, char *argv[])
 	progname = basename(argv[0]);
 	gdb_port = 0;
 	guest_ncpus = 1;
-	print_mac = 0;
 	memsize = 256 * MB;
 	mptgen = 1;
 	rtc_localtime = 1;
@@ -908,9 +906,6 @@ main(int argc, char *argv[])
 			error = parse_memsize(optarg, &memsize);
 			if (error)
 				errx(EX_USAGE, "invalid memsize '%s'", optarg);
-			break;
-		case 'M':
-			print_mac = 1;
 			break;
 		case 'H':
 			guest_vmexit_on_hlt = 1;

--- a/src/include/xhyve/xhyve.h
+++ b/src/include/xhyve/xhyve.h
@@ -41,7 +41,6 @@
 #define	VMEXIT_ABORT (-1)
 
 extern int guest_ncpus;
-extern int print_mac;
 extern char *guest_uuid_str;
 extern char *vmname;
 

--- a/src/lib/pci_virtio_net_vmnet.c
+++ b/src/lib/pci_virtio_net_vmnet.c
@@ -728,14 +728,6 @@ pci_vtnet_init(struct pci_devinst *pi, UNUSED char *opts)
 		return (-1);
 	}
 
-    if (print_mac == 1)
-    {
-		printf("MAC: %02x:%02x:%02x:%02x:%02x:%02x\n",
-			sc->vms->mac[0], sc->vms->mac[1], sc->vms->mac[2],
-			sc->vms->mac[3], sc->vms->mac[4], sc->vms->mac[5]);
-		exit(0);
-    }
-
 	sc->vsc_config.mac[0] = sc->vms->mac[0];
 	sc->vsc_config.mac[1] = sc->vms->mac[1];
 	sc->vsc_config.mac[2] = sc->vms->mac[2];


### PR DESCRIPTION
This global option was specific to one network backend,
irrespective of it being configured via -s.

It is also uncertain that a VM will get a the same MAC
address on a second invocation, so the usefulness of the
option is questionable.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>