### PR TITLE
Also remove the -M option from the help message

### DIFF
--- a/src/hyperkit.c
+++ b/src/hyperkit.c
@@ -145,7 +145,6 @@ usage(int code)
 		"       -H: vmexit from the guest on hlt\n"
 		"       -l: LPC device configuration. Ex: -l com1,stdio -l com2,autopty -l com2,/dev/myownpty\n"
 		"       -m: memory size in MB, may be suffixed with one of K, M, G or T\n"
-		"       -M: print MAC address and exit if using vmnet\n"
 		"       -P: vmexit from the guest on pause\n"
 		"       -s: <slot,driver,configinfo> PCI slot config\n"
 		"       -u: RTC keeps UTC time\n"


### PR DESCRIPTION
Missed this in the previous commit.

Signed-off-by: Rolf Neugebauer <rolf.neugebauer@docker.com>