### PR TITLE
Some improvements to the go bindings

### DIFF
--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -73,6 +73,8 @@ type HyperKit struct {
 	DiskImage string `json:"disk"`
 	// ISOImage is the (optional) path to a ISO image to attach
 	ISOImage string `json:"iso"`
+	// VSock enables the virtio-socket device and exposes it on the host
+	VSock bool `json:"vsock"`
 
 	// Kernel is the path to the kernel image to boot
 	Kernel string `json:"kernel"`
@@ -193,7 +195,7 @@ func (h *HyperKit) execute(cmdline string) error {
 	var err error
 	// Sanity checks on configuration
 	if h.Console == ConsoleFile && h.StateDir == "" {
-		return fmt.Errorf("If ConsoleFile is set, StateDir was be specified")
+		return fmt.Errorf("If ConsoleFile is set, StateDir must be specified")
 	}
 	if h.UserData != "" && h.ISOImage != "" {
 		return fmt.Errorf("If UserData is supplied, ISOImage must not be set")
@@ -203,8 +205,11 @@ func (h *HyperKit) execute(cmdline string) error {
 			return fmt.Errorf("ISO %s does not exist", h.ISOImage)
 		}
 	}
+	if h.VSock && h.StateDir == "" {
+		return fmt.Errorf("If virtio-sockets are enabled, StateDir must be specified")
+	}
 	if h.UserData != "" && h.StateDir == "" {
-		return fmt.Errorf("If UserData is supplied, StateDir was be specified")
+		return fmt.Errorf("If UserData is supplied, StateDir must be specified")
 	}
 	if _, err = os.Stat(h.Kernel); os.IsNotExist(err) {
 		return fmt.Errorf("Kernel %s does not exist", h.Kernel)
@@ -352,6 +357,9 @@ func (h *HyperKit) buildArgs(cmdline string) {
 	}
 	if h.DiskImage != "" {
 		a = append(a, "-s", fmt.Sprintf("2:0,virtio-blk,%s", h.DiskImage))
+	}
+	if h.VSock {
+		a = append(a, "-s", fmt.Sprintf("3,virtio-sock,guest_cid=3,path=%s", h.StateDir))
 	}
 	if h.ISOImage != "" {
 		a = append(a, "-s", fmt.Sprintf("4,ahci-cd,%s", h.ISOImage))

--- a/go/hyperkit.go
+++ b/go/hyperkit.go
@@ -1,5 +1,3 @@
-// +build darwin
-
 // Package hyperkit provides a Go wrapper around the hyperkit
 // command. It currently shells out to start hyperkit with the
 // provided configuration.

--- a/go/sample/main.go
+++ b/go/sample/main.go
@@ -26,6 +26,7 @@ func main() {
 	cpus := flag.Int("cpus", 1, "Number of CPUs")
 	mem := flag.Int("mem", 1024, "Amount of memory in MB")
 	diskSz := flag.Int("disk-size", 0, "Size of Disk in MB")
+	vsock := flag.Bool("vsock", false, "Enable virtio-sockets")
 
 	data := flag.String("data", "", "User data to pass to VM via ISO")
 
@@ -72,6 +73,7 @@ func main() {
 	h.CPUs = *cpus
 	h.Memory = *mem
 	h.DiskSize = *diskSz
+	h.VSock = *vsock
 
 	h.UserData = *data
 


### PR DESCRIPTION
- optionally enable the virtio-socket device (resolves #109)
- add a option to sample code to enable the virtio-socket device
- allow the hyperkit package to be used on non-macOS systems (to make it easier for downstream users to consume)