### PR TITLE
Fix compilation issues for Big Sur

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ _build
 /test/vmlinuz
 /test/initrd
 /test/initrd.gz
+/test/disk.dmg
 /test/disk.qcow2

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,8 @@ OCAML_PACKS := cstruct cstruct-lwt io-page io-page.unix uri mirage-block \
 	mirage-unix prometheus-app conduit-lwt cohttp-lwt-unix \
 	unix-type-representations
 OCAML_LDLIBS := -L $(OCAML_WHERE) \
+	$(shell ocamlfind query bigstringaf)/bigstringaf.a \
+	$(shell ocamlfind query bigstringaf)/libbigstringaf_stubs.a \
 	$(shell ocamlfind query cstruct)/cstruct.a \
 	$(shell ocamlfind query cstruct)/libcstruct_stubs.a \
 	$(shell ocamlfind query io-page)/io_page.a \

--- a/config.mk
+++ b/config.mk
@@ -80,4 +80,5 @@ LDFLAGS := \
   -arch x86_64 \
   -framework Hypervisor \
   -framework vmnet \
+  -Wl,-no_compact_unwind \
   $(LDFLAGS_DBG)

--- a/config.mk
+++ b/config.mk
@@ -45,7 +45,8 @@ CFLAGS_WARN := \
   -Wno-reserved-id-macro \
   -Wno-unknown-warning-option \
   -Wno-unused-macros \
-  -Wno-switch-enum
+  -Wno-switch-enum \
+  -Wno-poison-system-directories
 
 CFLAGS_DIAG := \
   -fmessage-length=152 \

--- a/src/lib/block_if.c
+++ b/src/lib/block_if.c
@@ -138,7 +138,7 @@ static struct blockif_sig_elem *blockif_bse_head;
 
 
 static ssize_t
-preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset)
+_preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset)
 {
 	off_t res;
 
@@ -149,7 +149,7 @@ preadv(int fd, const struct iovec *iov, int iovcnt, off_t offset)
 
 
 static ssize_t
-pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset)
+_pwritev(int fd, const struct iovec *iov, int iovcnt, off_t offset)
 {
 	off_t res;
 
@@ -181,7 +181,7 @@ block_preadv(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt,
 		HYPERKIT_BLOCK_PREADV(offset, iovec_len(iov, iovcnt));
 
 	if (bc->bc_fd >= 0)
-		ret = preadv(bc->bc_fd, iov, iovcnt, offset);
+		ret = _preadv(bc->bc_fd, iov, iovcnt, offset);
 
 #ifdef HAVE_OCAML_QCOW
 	else if (bc->bc_mbh >= 0)
@@ -205,7 +205,7 @@ block_pwritev(struct blockif_ctxt *bc, const struct iovec *iov, int iovcnt,
 		HYPERKIT_BLOCK_PWRITEV(offset, iovec_len(iov, iovcnt));
 
 	if (bc->bc_fd >= 0)
-		ret = pwritev(bc->bc_fd, iov, iovcnt, offset);
+		ret = _pwritev(bc->bc_fd, iov, iovcnt, offset);
 
 #ifdef HAVE_OCAML_QCOW
 	else if (bc->bc_mbh >= 0)

--- a/src/lib/vmm/intel/vmx.c
+++ b/src/lib/vmm/intel/vmx.c
@@ -491,9 +491,12 @@ vmx_init(void)
 		case HV_UNSUPPORTED:
 			/* Don't know if this can happen, report to us */
 			xhyve_abort("hv_vm_create HV_UNSUPPORTED\n");
+		case HV_ERROR:
+			/* An unspecified error happened */
+			xhyve_abort("hv_vm_create HV_ERROR (unspecified error)\n");
 		default:
 			/* Should never happen, report to Apple */
-			xhyve_abort("hv_vm_create unknown error %d\n", error);
+			xhyve_abort("hv_vm_create unknown error %#010x\n", error);
 	}
 
 	/*


### PR DESCRIPTION
Fix compiling hyperkit on macOS Big Sur.

The resulting binary still does not work, I'm now getting:
```
./build/hyperkit -A -m 512M -s 0:0,hostbridge -s 31,lpc -l com1,stdio -s 1:0,ahci-hd,/dev/rdisk7 -f kexec,./vmlinuz,./initrd.gz,earlyprintk=serial console=ttyS0 noapic nosmp
hv_vm_create HV_ERROR (unspecified error)
Abort trap: 6
```
