### PR TITLE
Set no error for 'unused-but-set-variable' warning

### DIFF
--- a/config.mk
+++ b/config.mk
@@ -47,7 +47,8 @@ CFLAGS_WARN := \
   -Wno-unknown-warning-option \
   -Wno-unused-macros \
   -Wno-switch-enum \
-  -Wno-poison-system-directories
+  -Wno-poison-system-directories \
+  -Wno-error=unused-but-set-variable
 
 CFLAGS_DIAG := \
   -fmessage-length=152 \


### PR DESCRIPTION
I add some changes in config.mk for this issue #332. 